### PR TITLE
feat: Remove zero address checks and tests (SC-501)

### DIFF
--- a/src/PSM3.sol
+++ b/src/PSM3.sol
@@ -106,8 +106,7 @@ contract PSM3 is IPSM3 {
     function deposit(address asset, address receiver, uint256 assetsToDeposit)
         external override returns (uint256 newShares)
     {
-        require(receiver != address(0), "PSM3/invalid-receiver");
-        require(assetsToDeposit != 0,   "PSM3/invalid-amount");
+        require(assetsToDeposit != 0, "PSM3/invalid-amount");
 
         newShares = previewDeposit(asset, assetsToDeposit);
 
@@ -122,7 +121,6 @@ contract PSM3 is IPSM3 {
     function withdraw(address asset, address receiver, uint256 maxAssetsToWithdraw)
         external override returns (uint256 assetsWithdrawn)
     {
-        require(receiver != address(0),   "PSM3/invalid-receiver");
         require(maxAssetsToWithdraw != 0, "PSM3/invalid-amount");
 
         uint256 sharesToBurn;

--- a/test/invariant/Invariants.t.sol
+++ b/test/invariant/Invariants.t.sol
@@ -25,7 +25,7 @@ abstract contract PSMInvariantTestBase is PSMTestBase {
     TransferHandler      public transferHandler;
     TimeBasedRateHandler public timeBasedRateHandler;
 
-    address BURN_ADDRESS = makeAddr("burn-address");
+    address BURN_ADDRESS = address(0);
 
     // NOTE [CRITICAL]: All invariant tests are operating under the assumption that the initial seed
     //                  deposit of 1e18 shares has been made. This is a key requirement and

--- a/test/unit/Deposit.t.sol
+++ b/test/unit/Deposit.t.sol
@@ -14,11 +14,6 @@ contract PSMDepositTests is PSMTestBase {
     address receiver1 = makeAddr("receiver1");
     address receiver2 = makeAddr("receiver2");
 
-    function test_deposit_zeroReceiver() public {
-        vm.expectRevert("PSM3/invalid-receiver");
-        psm.deposit(address(usdc), address(0), 100e6);
-    }
-
     function test_deposit_zeroAmount() public {
         vm.expectRevert("PSM3/invalid-amount");
         psm.deposit(address(usdc), user1, 0);

--- a/test/unit/Withdraw.t.sol
+++ b/test/unit/Withdraw.t.sol
@@ -16,13 +16,6 @@ contract PSMWithdrawTests is PSMTestBase {
     address receiver1 = makeAddr("receiver1");
     address receiver2 = makeAddr("receiver2");
 
-    function test_withdraw_zeroReceiver() public {
-        _deposit(address(usdc), user1, 100e6);
-
-        vm.expectRevert("PSM3/invalid-receiver");
-        psm.withdraw(address(usdc), address(0), 100e6);
-    }
-
     function test_withdraw_zeroAmount() public {
         _deposit(address(usdc), user1, 100e6);
 


### PR DESCRIPTION
Reasoning: SubDAOs are the only ones doing deposits and withdraws and zero address should be used for initial burning of shares.