### PR TITLE
feat: Add Coinbase Custody support, refactor to use named assets, DAI => USDS (SC-672)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,16 @@ The deployment library (`deploy/PSM3Deploy.sol`) in this repo contains logic for
 - **`asset0`**: Non-yield-bearing base asset (e.g., USDC).
 - **`asset1`**: Another non-yield-bearing base asset that is directly correlated to `asset0` (e.g., DAI).
 - **`asset2`**: Yield-bearing version of both `asset0` and `asset1` (e.g., sDAI).
+- **`pocket`**: Address that holds custody of asset0. The `pocket` can deploy asset0 to yield-bearing strategies. Defaulted to the address of the PSM itself.
 - **`rateProvider`**: Contract that returns a conversion rate between and `asset2` and the base asset (e.g., sDAI to USD) in 1e27 precision.
 - **`totalShares`**: Total shares in the PSM. Shares represent the ownership of the underlying assets in the PSM.
 - **`shares`**: Mapping of user addresses to their shares.
 
 ### Functions
+
+#### Admin Functions
+
+- **`setPocket`**: Sets the `pocket` address. Only the `owner` can call this function. This is a very important and sensitive action because it transfers the entire balance of `asset0` to the new `pocket` address. OZ Ownable is used for this function, and `owner` will always be set to the governance proxy.
 
 #### Swap Functions
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 This repository contains the implementation of a Peg Stability Module (PSM) contract, which facilitates the swapping, depositing, and withdrawing of three given assets to maintain stability and ensure the peg of involved assets. The PSM supports both yield-bearing and non-yield-bearing assets.
 
-`asset0` and `asset1` are two ERC20 tokens that are directly correlated and are non-yield-bearing, referred to as "base assets". `asset2` is a yield-bearing version of both `asset0` and `asset1`. The PSM contract allows users to swap between these assets, deposit any of the assets to mint shares, and withdraw any of the assets by burning shares.
+The PSM contract allows users to swap between USDC, USDS, and sSUDS, deposit any of the assets to mint shares, and withdraw any of the assets by burning shares.
 
-The conversion between a base asset and `asset2` is provided by a rate provider contract. The rate provider returns the conversion rate between `asset2` and the base asset in 1e27 precision. The conversion between the base assets is one to one.
+The conversion between a stablecoin and `susds` is provided by a rate provider contract. The rate provider returns the conversion rate between `susds` and the stablecoin in 1e27 precision. The conversion between the stablecoins is one to one.
 
-The conversion rate between assets and shares is based on the total value of assets held by the PSM. The total value is calculated by converting the assets to their equivalent value in the base asset with 18 decimal precision. The shares represent the ownership of the underlying assets in the PSM. Since three assets are used, each with different precisions and values, they are converted to a common base asset-denominated value for share conversions.
+The conversion rate between assets and shares is based on the total value of assets held by the PSM. The total value is calculated by converting the assets to their equivalent value in USD with 18 decimal precision. The shares represent the ownership of the underlying assets in the PSM. Since three assets are used, each with different precisions and values, they are converted to a common USD-denominated value for share conversions.
 
 For detailed implementation, refer to the contract code and `IPSM3` interface documentation.
 
@@ -39,11 +39,11 @@ The deployment library (`deploy/PSM3Deploy.sol`) in this repo contains logic for
 
 ### State Variables and Immutables
 
-- **`asset0`**: Non-yield-bearing base asset (e.g., USDC).
-- **`asset1`**: Another non-yield-bearing base asset that is directly correlated to `asset0` (e.g., USDS).
-- **`asset2`**: Yield-bearing version of both `asset0` and `asset1` (e.g., sUSDS).
-- **`pocket`**: Address that holds custody of asset0. The `pocket` can deploy asset0 to yield-bearing strategies. Defaulted to the address of the PSM itself.
-- **`rateProvider`**: Contract that returns a conversion rate between and `asset2` and the base asset (e.g., sUSDS to USD) in 1e27 precision.
+- **`usdc`**: IERC20 interface of USDC.
+- **`usds`**: IERC20 interface of USDS.
+- **`susds`**: IERC20 interface of sUSDS. Note that this is an ERC20 and not a ERC4626 because it's not on mainnet.
+- **`pocket`**: Address that holds custody of USDC. The `pocket` can deploy USDC to yield-bearing strategies. Defaulted to the address of the PSM itself.
+- **`rateProvider`**: Contract that returns a conversion rate between and sUSDS and USD in 1e27 precision.
 - **`totalShares`**: Total shares in the PSM. Shares represent the ownership of the underlying assets in the PSM.
 - **`shares`**: Mapping of user addresses to their shares.
 
@@ -51,7 +51,7 @@ The deployment library (`deploy/PSM3Deploy.sol`) in this repo contains logic for
 
 #### Admin Functions
 
-- **`setPocket`**: Sets the `pocket` address. Only the `owner` can call this function. This is a very important and sensitive action because it transfers the entire balance of `asset0` to the new `pocket` address. OZ Ownable is used for this function, and `owner` will always be set to the governance proxy.
+- **`setPocket`**: Sets the `pocket` address. Only the `owner` can call this function. This is a very important and sensitive action because it transfers the entire balance of USDC to the new `pocket` address. OZ Ownable is used for this function, and `owner` will always be set to the governance proxy.
 
 #### Swap Functions
 
@@ -75,12 +75,12 @@ The deployment library (`deploy/PSM3Deploy.sol`) in this repo contains logic for
 NOTE: These functions do not round in the same way as preview functions, so they are meant to be used for general quoting purposes.
 
 - **`convertToAssets`**: Converts shares to the equivalent amount of a specified asset.
-- **`convertToAssetValue`**: Converts shares to their equivalent value in base asset terms with 18 decimal precision (e.g., USD).
+- **`convertToAssetValue`**: Converts shares to their equivalent value in USD terms with 18 decimal precision.
 - **`convertToShares`**: Converts asset values to shares based on the current exchange rate.
 
 #### Asset Value Functions
 
-- **`totalAssets`**: Returns the total value of all assets held by the PSM denominated in the base asset with 18 decimal precision. (e.g., USD).
+- **`totalAssets`**: Returns the total value of all assets held by the PSM denominated in USD with 18 decimal precision.
 
 ### Events
 

--- a/deploy/PSM3Deploy.sol
+++ b/deploy/PSM3Deploy.sol
@@ -8,6 +8,7 @@ import { PSM3 } from "src/PSM3.sol";
 library PSM3Deploy {
 
     function deploy(
+        address admin,
         address asset0,
         address asset1,
         address asset2,
@@ -15,7 +16,7 @@ library PSM3Deploy {
     )
         external returns (address psm)
     {
-        psm = address(new PSM3(asset0, asset1, asset2, rateProvider));
+        psm = address(new PSM3(admin, asset0, asset1, asset2, rateProvider));
 
         IERC20(asset0).approve(psm, 1e18);
         PSM3(psm).deposit(asset0, address(0), 1e18);

--- a/deploy/PSM3Deploy.sol
+++ b/deploy/PSM3Deploy.sol
@@ -8,7 +8,7 @@ import { PSM3 } from "src/PSM3.sol";
 library PSM3Deploy {
 
     function deploy(
-        address admin,
+        address owner,
         address asset0,
         address asset1,
         address asset2,
@@ -16,7 +16,7 @@ library PSM3Deploy {
     )
         external returns (address psm)
     {
-        psm = address(new PSM3(admin, asset0, asset1, asset2, rateProvider));
+        psm = address(new PSM3(owner, asset0, asset1, asset2, rateProvider));
 
         IERC20(asset0).approve(psm, 1e18);
         PSM3(psm).deposit(asset0, address(0), 1e18);

--- a/deploy/PSM3Deploy.sol
+++ b/deploy/PSM3Deploy.sol
@@ -18,8 +18,8 @@ library PSM3Deploy {
     {
         psm = address(new PSM3(owner, asset0, asset1, asset2, rateProvider));
 
-        IERC20(asset0).approve(psm, 1e18);
-        PSM3(psm).deposit(asset0, address(0), 1e18);
+        IERC20(asset1).approve(psm, 1e18);
+        PSM3(psm).deposit(asset1, address(0), 1e18);
     }
 
 }

--- a/deploy/PSM3Deploy.sol
+++ b/deploy/PSM3Deploy.sol
@@ -9,17 +9,17 @@ library PSM3Deploy {
 
     function deploy(
         address owner,
-        address asset0,
-        address asset1,
-        address asset2,
+        address usdc,
+        address usds,
+        address susds,
         address rateProvider
     )
         external returns (address psm)
     {
-        psm = address(new PSM3(owner, asset0, asset1, asset2, rateProvider));
+        psm = address(new PSM3(owner, usdc, usds, susds, rateProvider));
 
-        IERC20(asset1).approve(psm, 1e18);
-        PSM3(psm).deposit(asset1, address(0), 1e18);
+        IERC20(usds).approve(psm, 1e18);
+        PSM3(psm).deposit(usds, address(0), 1e18);
     }
 
 }

--- a/src/PSM3.sol
+++ b/src/PSM3.sol
@@ -5,12 +5,13 @@ import { IERC20 } from "erc20-helpers/interfaces/IERC20.sol";
 
 import { SafeERC20 } from "erc20-helpers/SafeERC20.sol";
 
-import { Math } from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+import { Ownable } from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import { Math }    from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 
 import { IPSM3 }             from "src/interfaces/IPSM3.sol";
 import { IRateProviderLike } from "src/interfaces/IRateProviderLike.sol";
 
-contract PSM3 is IPSM3 {
+contract PSM3 is IPSM3, Ownable {
 
     using SafeERC20 for IERC20;
 
@@ -25,12 +26,21 @@ contract PSM3 is IPSM3 {
     IERC20 public override immutable asset2;
 
     address public override immutable rateProvider;
+    address public override immutable pocket;
 
     uint256 public override totalShares;
 
     mapping(address user => uint256 shares) public override shares;
 
-    constructor(address asset0_, address asset1_, address asset2_, address rateProvider_) {
+    constructor(
+        address owner_,
+        address asset0_,
+        address asset1_,
+        address asset2_,
+        address rateProvider_
+    )
+        Ownable(owner_)
+    {
         require(asset0_       != address(0), "PSM3/invalid-asset0");
         require(asset1_       != address(0), "PSM3/invalid-asset1");
         require(asset2_       != address(0), "PSM3/invalid-asset2");
@@ -45,6 +55,7 @@ contract PSM3 is IPSM3 {
         asset2 = IERC20(asset2_);
 
         rateProvider = rateProvider_;
+        pocket       = address(this);
 
         require(
             IRateProviderLike(rateProvider_).getConversionRate() != 0,

--- a/src/PSM3.sol
+++ b/src/PSM3.sol
@@ -19,8 +19,13 @@ contract PSM3 is IPSM3, Ownable {
     uint256 internal immutable _asset1Precision;
     uint256 internal immutable _asset2Precision;
 
-    // NOTE: Assumption is made that asset2 is the yield-bearing counterpart of asset0 and asset1.
-    //       Examples: asset0 = USDC, asset1 = DAI, asset2 = sDAI
+    // NOTE(CRITICAL): Multiple assumptions are made about the initial configuration of this
+    //                 contract that are critical to it functioning correctly.
+    //                 These assumptions are:
+    //                 Assumption 1: `asset2` is the yield-bearing counterpart of asset0 and asset1.
+    //                 Assumption 2: `asset0` is the only asset that can be used with a `pocket`.
+    //                 Example: asset0 = USDC, asset1 = DAI, asset2 = sDAI
+
     IERC20 public override immutable asset0;
     IERC20 public override immutable asset1;
     IERC20 public override immutable asset2;

--- a/src/PSM3.sol
+++ b/src/PSM3.sol
@@ -77,17 +77,21 @@ contract PSM3 is IPSM3, Ownable {
     function setPocket(address newPocket) external override onlyOwner {
         require(newPocket != address(0), "PSM3/invalid-pocket");
 
-        uint256 amountToTransfer = usdc.balanceOf(pocket);
+        address pocket_ = pocket;
 
-        if (pocket == address(this)) {
+        require(newPocket != pocket_, "PSM3/same-pocket");
+
+        uint256 amountToTransfer = usdc.balanceOf(pocket_);
+
+        if (pocket_ == address(this)) {
             usdc.safeTransfer(newPocket, amountToTransfer);
         } else {
-            usdc.safeTransferFrom(pocket, newPocket, amountToTransfer);
+            usdc.safeTransferFrom(pocket_, newPocket, amountToTransfer);
         }
 
-        emit PocketSet(pocket, newPocket, amountToTransfer);
-
         pocket = newPocket;
+
+        emit PocketSet(pocket_, newPocket, amountToTransfer);
     }
 
     /**********************************************************************************************/

--- a/src/PSM3.sol
+++ b/src/PSM3.sol
@@ -81,8 +81,7 @@ contract PSM3 is IPSM3, Ownable {
     /*** Owner functions                                                                        ***/
     /**********************************************************************************************/
 
-    // TODO: Add override
-    function setPocket(address newPocket) external onlyOwner {
+    function setPocket(address newPocket) external override onlyOwner {
         require(newPocket != address(0), "PSM3/invalid-pocket");
 
         uint256 amountToTransfer = asset0.balanceOf(pocket);

--- a/src/PSM3.sol
+++ b/src/PSM3.sol
@@ -26,7 +26,8 @@ contract PSM3 is IPSM3, Ownable {
     IERC20 public override immutable asset2;
 
     address public override immutable rateProvider;
-    address public override immutable pocket;
+
+    address public override pocket;
 
     uint256 public override totalShares;
 
@@ -69,6 +70,27 @@ contract PSM3 is IPSM3, Ownable {
         // Necessary to ensure rounding works as expected
         require(_asset0Precision <= 1e18, "PSM3/asset0-precision-too-high");
         require(_asset1Precision <= 1e18, "PSM3/asset1-precision-too-high");
+    }
+
+    /**********************************************************************************************/
+    /*** Owner functions                                                                        ***/
+    /**********************************************************************************************/
+
+    // TODO: Add override
+    function setPocket(address newPocket) external onlyOwner {
+        require(newPocket != address(0), "PSM3/invalid-pocket");
+
+        uint256 amountToTransfer = asset0.balanceOf(pocket);
+
+        if (pocket == address(this)) {
+            asset0.safeTransfer(newPocket, amountToTransfer);
+        } else {
+            asset0.safeTransferFrom(pocket, newPocket, amountToTransfer);
+        }
+
+        pocket = newPocket;
+
+        emit PocketSet(pocket, newPocket, amountToTransfer);
     }
 
     /**********************************************************************************************/

--- a/src/PSM3.sol
+++ b/src/PSM3.sol
@@ -93,9 +93,9 @@ contract PSM3 is IPSM3, Ownable {
             asset0.safeTransferFrom(pocket, newPocket, amountToTransfer);
         }
 
-        pocket = newPocket;
-
         emit PocketSet(pocket, newPocket, amountToTransfer);
+
+        pocket = newPocket;
     }
 
     /**********************************************************************************************/

--- a/src/PSM3.sol
+++ b/src/PSM3.sol
@@ -15,20 +15,13 @@ contract PSM3 is IPSM3, Ownable {
 
     using SafeERC20 for IERC20;
 
-    uint256 internal immutable _asset0Precision;
-    uint256 internal immutable _asset1Precision;
-    uint256 internal immutable _asset2Precision;
+    uint256 internal immutable _usdcPrecision;
+    uint256 internal immutable _usdsPrecision;
+    uint256 internal immutable _susdsPrecision;
 
-    // NOTE(CRITICAL): Multiple assumptions are made about the initial configuration of this
-    //                 contract that are critical to it functioning correctly.
-    //                 These assumptions are:
-    //                 Assumption 1: `asset2` is the yield-bearing counterpart of asset0 and asset1.
-    //                 Assumption 2: `asset0` is the only asset that can be used with a `pocket`.
-    //                 Example: asset0 = USDC, asset1 = DAI, asset2 = sDAI
-
-    IERC20 public override immutable asset0;
-    IERC20 public override immutable asset1;
-    IERC20 public override immutable asset2;
+    IERC20 public override immutable usdc;
+    IERC20 public override immutable usds;
+    IERC20 public override immutable susds;
 
     address public override immutable rateProvider;
 
@@ -40,25 +33,25 @@ contract PSM3 is IPSM3, Ownable {
 
     constructor(
         address owner_,
-        address asset0_,
-        address asset1_,
-        address asset2_,
+        address usdc_,
+        address usds_,
+        address susds_,
         address rateProvider_
     )
         Ownable(owner_)
     {
-        require(asset0_       != address(0), "PSM3/invalid-asset0");
-        require(asset1_       != address(0), "PSM3/invalid-asset1");
-        require(asset2_       != address(0), "PSM3/invalid-asset2");
+        require(usdc_         != address(0), "PSM3/invalid-usdc");
+        require(usds_         != address(0), "PSM3/invalid-usds");
+        require(susds_        != address(0), "PSM3/invalid-susds");
         require(rateProvider_ != address(0), "PSM3/invalid-rateProvider");
 
-        require(asset0_ != asset1_, "PSM3/asset0-asset1-same");
-        require(asset0_ != asset2_, "PSM3/asset0-asset2-same");
-        require(asset1_ != asset2_, "PSM3/asset1-asset2-same");
+        require(usdc_ != usds_,  "PSM3/usdc-usds-same");
+        require(usdc_ != susds_, "PSM3/usdc-susds-same");
+        require(usds_ != susds_, "PSM3/usds-susds-same");
 
-        asset0 = IERC20(asset0_);
-        asset1 = IERC20(asset1_);
-        asset2 = IERC20(asset2_);
+        usdc  = IERC20(usdc_);
+        usds  = IERC20(usds_);
+        susds = IERC20(susds_);
 
         rateProvider = rateProvider_;
         pocket       = address(this);
@@ -68,13 +61,13 @@ contract PSM3 is IPSM3, Ownable {
             "PSM3/rate-provider-returns-zero"
         );
 
-        _asset0Precision = 10 ** IERC20(asset0_).decimals();
-        _asset1Precision = 10 ** IERC20(asset1_).decimals();
-        _asset2Precision = 10 ** IERC20(asset2_).decimals();
+        _usdcPrecision  = 10 ** IERC20(usdc_).decimals();
+        _usdsPrecision  = 10 ** IERC20(usds_).decimals();
+        _susdsPrecision = 10 ** IERC20(susds_).decimals();
 
         // Necessary to ensure rounding works as expected
-        require(_asset0Precision <= 1e18, "PSM3/asset0-precision-too-high");
-        require(_asset1Precision <= 1e18, "PSM3/asset1-precision-too-high");
+        require(_usdcPrecision <= 1e18, "PSM3/usdc-precision-too-high");
+        require(_usdsPrecision <= 1e18, "PSM3/usds-precision-too-high");
     }
 
     /**********************************************************************************************/
@@ -84,12 +77,12 @@ contract PSM3 is IPSM3, Ownable {
     function setPocket(address newPocket) external override onlyOwner {
         require(newPocket != address(0), "PSM3/invalid-pocket");
 
-        uint256 amountToTransfer = asset0.balanceOf(pocket);
+        uint256 amountToTransfer = usdc.balanceOf(pocket);
 
         if (pocket == address(this)) {
-            asset0.safeTransfer(newPocket, amountToTransfer);
+            usdc.safeTransfer(newPocket, amountToTransfer);
         } else {
-            asset0.safeTransferFrom(pocket, newPocket, amountToTransfer);
+            usdc.safeTransferFrom(pocket, newPocket, amountToTransfer);
         }
 
         emit PocketSet(pocket, newPocket, amountToTransfer);
@@ -195,7 +188,7 @@ contract PSM3 is IPSM3, Ownable {
     {
         require(_isValidAsset(asset), "PSM3/invalid-asset");
 
-        // Convert amount to 1e18 precision denominated in value of asset0 then convert to shares.
+        // Convert amount to 1e18 precision denominated in value of USD then convert to shares.
         return convertToShares(_getAssetValue(asset, assetsToDeposit, false));  // Round down
     }
 
@@ -250,13 +243,13 @@ contract PSM3 is IPSM3, Ownable {
 
         uint256 assetValue = convertToAssetValue(numShares);
 
-        if      (asset == address(asset0)) return assetValue * _asset0Precision / 1e18;
-        else if (asset == address(asset1)) return assetValue * _asset1Precision / 1e18;
+        if      (asset == address(usdc)) return assetValue * _usdcPrecision / 1e18;
+        else if (asset == address(usds)) return assetValue * _usdsPrecision / 1e18;
 
         // NOTE: Multiplying by 1e27 and dividing by 1e18 cancels to 1e9 in numerator
         return assetValue
             * 1e9
-            * _asset2Precision
+            * _susdsPrecision
             / IRateProviderLike(rateProvider).getConversionRate();
     }
 
@@ -287,9 +280,9 @@ contract PSM3 is IPSM3, Ownable {
     /**********************************************************************************************/
 
     function totalAssets() public view override returns (uint256) {
-        return _getAsset0Value(asset0.balanceOf(address(this)))
-            +  _getAsset1Value(asset1.balanceOf(address(this)))
-            +  _getAsset2Value(asset2.balanceOf(address(this)), false);  // Round down
+        return _getUsdcValue(usdc.balanceOf(address(this)))
+            +  _getUsdsValue(usds.balanceOf(address(this)))
+            +  _getSUsdsValue(susds.balanceOf(address(this)), false);  // Round down
     }
 
     /**********************************************************************************************/
@@ -297,30 +290,30 @@ contract PSM3 is IPSM3, Ownable {
     /**********************************************************************************************/
 
     function _getAssetValue(address asset, uint256 amount, bool roundUp) internal view returns (uint256) {
-        if      (asset == address(asset0)) return _getAsset0Value(amount);
-        else if (asset == address(asset1)) return _getAsset1Value(amount);
-        else if (asset == address(asset2)) return _getAsset2Value(amount, roundUp);
+        if      (asset == address(usdc))  return _getUsdcValue(amount);
+        else if (asset == address(usds))  return _getUsdsValue(amount);
+        else if (asset == address(susds)) return _getSUsdsValue(amount, roundUp);
         else revert("PSM3/invalid-asset");
     }
 
-    function _getAsset0Value(uint256 amount) internal view returns (uint256) {
-        return amount * 1e18 / _asset0Precision;
+    function _getUsdcValue(uint256 amount) internal view returns (uint256) {
+        return amount * 1e18 / _usdcPrecision;
     }
 
-    function _getAsset1Value(uint256 amount) internal view returns (uint256) {
-        return amount * 1e18 / _asset1Precision;
+    function _getUsdsValue(uint256 amount) internal view returns (uint256) {
+        return amount * 1e18 / _usdsPrecision;
     }
 
-    function _getAsset2Value(uint256 amount, bool roundUp) internal view returns (uint256) {
+    function _getSUsdsValue(uint256 amount, bool roundUp) internal view returns (uint256) {
         // NOTE: Multiplying by 1e18 and dividing by 1e27 cancels to 1e9 in denominator
         if (!roundUp) return amount
             * IRateProviderLike(rateProvider).getConversionRate()
             / 1e9
-            / _asset2Precision;
+            / _susdsPrecision;
 
         return Math.ceilDiv(
             Math.ceilDiv(amount * IRateProviderLike(rateProvider).getConversionRate(), 1e9),
-            _asset2Precision
+            _susdsPrecision
         );
     }
 
@@ -331,47 +324,47 @@ contract PSM3 is IPSM3, Ownable {
     function _getSwapQuote(address asset, address quoteAsset, uint256 amount, bool roundUp)
         internal view returns (uint256 quoteAmount)
     {
-        if (asset == address(asset0)) {
-            if      (quoteAsset == address(asset1)) return _convertOneToOne(amount, _asset0Precision, _asset1Precision, roundUp);
-            else if (quoteAsset == address(asset2)) return _convertToAsset2(amount, _asset0Precision, roundUp);
+        if (asset == address(usdc)) {
+            if      (quoteAsset == address(usds))  return _convertOneToOne(amount, _usdcPrecision, _usdsPrecision, roundUp);
+            else if (quoteAsset == address(susds)) return _convertToSUsds(amount, _usdcPrecision, roundUp);
         }
 
-        else if (asset == address(asset1)) {
-            if      (quoteAsset == address(asset0)) return _convertOneToOne(amount, _asset1Precision, _asset0Precision, roundUp);
-            else if (quoteAsset == address(asset2)) return _convertToAsset2(amount, _asset1Precision, roundUp);
+        else if (asset == address(usds)) {
+            if      (quoteAsset == address(usdc))  return _convertOneToOne(amount, _usdsPrecision, _usdcPrecision, roundUp);
+            else if (quoteAsset == address(susds)) return _convertToSUsds(amount, _usdsPrecision, roundUp);
         }
 
-        else if (asset == address(asset2)) {
-            if      (quoteAsset == address(asset0)) return _convertFromAsset2(amount, _asset0Precision, roundUp);
-            else if (quoteAsset == address(asset1)) return _convertFromAsset2(amount, _asset1Precision, roundUp);
+        else if (asset == address(susds)) {
+            if      (quoteAsset == address(usdc)) return _convertFromSUsds(amount, _usdcPrecision, roundUp);
+            else if (quoteAsset == address(usds)) return _convertFromSUsds(amount, _usdsPrecision, roundUp);
         }
 
         revert("PSM3/invalid-asset");
     }
 
-    function _convertToAsset2(uint256 amount, uint256 assetPrecision, bool roundUp)
+    function _convertToSUsds(uint256 amount, uint256 assetPrecision, bool roundUp)
         internal view returns (uint256)
     {
         uint256 rate = IRateProviderLike(rateProvider).getConversionRate();
 
-        if (!roundUp) return amount * 1e27 / rate * _asset2Precision / assetPrecision;
+        if (!roundUp) return amount * 1e27 / rate * _susdsPrecision / assetPrecision;
 
         return Math.ceilDiv(
-            Math.ceilDiv(amount * 1e27, rate) * _asset2Precision,
+            Math.ceilDiv(amount * 1e27, rate) * _susdsPrecision,
             assetPrecision
         );
     }
 
-    function _convertFromAsset2(uint256 amount, uint256 assetPrecision, bool roundUp)
+    function _convertFromSUsds(uint256 amount, uint256 assetPrecision, bool roundUp)
         internal view returns (uint256)
     {
         uint256 rate = IRateProviderLike(rateProvider).getConversionRate();
 
-        if (!roundUp) return amount * rate / 1e27 * assetPrecision / _asset2Precision;
+        if (!roundUp) return amount * rate / 1e27 * assetPrecision / _susdsPrecision;
 
         return Math.ceilDiv(
             Math.ceilDiv(amount * rate, 1e27) * assetPrecision,
-            _asset2Precision
+            _susdsPrecision
         );
     }
 
@@ -401,7 +394,7 @@ contract PSM3 is IPSM3, Ownable {
     }
 
     function _isValidAsset(address asset) internal view returns (bool) {
-        return asset == address(asset0) || asset == address(asset1) || asset == address(asset2);
+        return asset == address(usdc) || asset == address(usds) || asset == address(susds);
     }
 
 }

--- a/src/interfaces/IPSM3.sol
+++ b/src/interfaces/IPSM3.sol
@@ -9,6 +9,13 @@ interface IPSM3 {
     /*** Events                                                                                 ***/
     /**********************************************************************************************/
 
+    // TODO: Add natspec
+    event PocketSet(
+        address indexed oldPocket,
+        address indexed newPocket,
+        uint256 amountTransferred
+    );
+
     /**
      *  @dev   Emitted when an asset is swapped in the PSM.
      *  @param assetIn       Address of the asset swapped in.

--- a/src/interfaces/IPSM3.sol
+++ b/src/interfaces/IPSM3.sol
@@ -9,7 +9,13 @@ interface IPSM3 {
     /*** Events                                                                                 ***/
     /**********************************************************************************************/
 
-    // TODO: Add natspec
+    /**
+     *  @dev   Emitted when a new pocket is set in the PSM, transferring the balance of asset0
+     *         of the old pocket to the new pocket.
+     *  @param oldPocket         Address of the old `pocket`.
+     *  @param newPocket         Address of the new `pocket`.
+     *  @param amountTransferred Amount of asset0 transferred from the old pocket to the new pocket.
+     */
     event PocketSet(
         address indexed oldPocket,
         address indexed newPocket,
@@ -121,6 +127,18 @@ interface IPSM3 {
      *  @return The number of shares held by the user.
      */
     function shares(address user) external view returns (uint256);
+
+    /**********************************************************************************************/
+    /*** Owner functions                                                                        ***/
+    /**********************************************************************************************/
+
+    /**
+     *  @dev    Sets the address of the pocket, an address that holds custody of asset0 in the PSM
+     *          and can deploy it to yield-bearing strategies. This function will transfer the
+     *          balance of USDC in the PSM to the new pocket. Callable only by the owner.
+     *  @param  newPocket Address of the new pocket.
+     */
+    function setPocket(address newPocket) external;
 
     /**********************************************************************************************/
     /*** Swap functions                                                                         ***/

--- a/src/interfaces/IPSM3.sol
+++ b/src/interfaces/IPSM3.sol
@@ -92,7 +92,7 @@ interface IPSM3 {
 
     /**
      *  @dev    Returns the IERC20 interface representing sUSDS. This asset is the yield-bearing
-     *          asset in the PSM (e.g., sDAI). The value of this asset is queried from the
+     *          asset in the PSM (e.g., sUSDS). The value of this asset is queried from the
      *          rate provider.
      *  @return The IERC20 interface of sUSDS.
      */
@@ -107,7 +107,7 @@ interface IPSM3 {
 
     /**
      *  @dev    Returns the address of the rate provider, a contract that provides the conversion
-     *          rate between sUSDS and the other two assets in the PSM (e.g., sDAI to USD).
+     *          rate between sUSDS and the other two assets in the PSM (e.g., sUSDS to USD).
      *  @return The address of the rate provider.
      */
     function rateProvider() external view returns (address);

--- a/src/interfaces/IPSM3.sol
+++ b/src/interfaces/IPSM3.sol
@@ -10,11 +10,11 @@ interface IPSM3 {
     /**********************************************************************************************/
 
     /**
-     *  @dev   Emitted when a new pocket is set in the PSM, transferring the balance of asset0
+     *  @dev   Emitted when a new pocket is set in the PSM, transferring the balance of USDC.
      *         of the old pocket to the new pocket.
      *  @param oldPocket         Address of the old `pocket`.
      *  @param newPocket         Address of the new `pocket`.
-     *  @param amountTransferred Amount of asset0 transferred from the old pocket to the new pocket.
+     *  @param amountTransferred Amount of USDC transferred from the old pocket to the new pocket.
      */
     event PocketSet(
         address indexed oldPocket,
@@ -79,26 +79,24 @@ interface IPSM3 {
     /**********************************************************************************************/
 
     /**
-     *  @dev    Returns the IERC20 interface representing asset0. This asset is one of the non-yield
-     *          bearing assets in the PSM (e.g., USDC or DAI).
-     *  @return The IERC20 interface of asset0.
+     *  @dev    Returns the IERC20 interface representing USDC.
+     *  @return The IERC20 interface of USDC.
      */
-    function asset0() external view returns (IERC20);
+    function usdc() external view returns (IERC20);
 
     /**
-     *  @dev    Returns the IERC20 interface representing asset1. This asset is one of the non-yield
-     *          bearing assets in the PSM (e.g., USDC or DAI).
-     *  @return The IERC20 interface of asset1.
+     *  @dev    Returns the IERC20 interface representing USDS.
+     *  @return The IERC20 interface of USDS.
      */
-    function asset1() external view returns (IERC20);
+    function usds() external view returns (IERC20);
 
     /**
-     *  @dev    Returns the IERC20 interface representing asset2. This asset is the yield-bearing
+     *  @dev    Returns the IERC20 interface representing sUSDS. This asset is the yield-bearing
      *          asset in the PSM (e.g., sDAI). The value of this asset is queried from the
      *          rate provider.
-     *  @return The IERC20 interface of asset2.
+     *  @return The IERC20 interface of sUSDS.
      */
-    function asset2() external view returns (IERC20);
+    function susds() external view returns (IERC20);
 
     /**
      *  @dev    Returns the address of the pocket, an address that holds custody of USDC in the
@@ -109,7 +107,7 @@ interface IPSM3 {
 
     /**
      *  @dev    Returns the address of the rate provider, a contract that provides the conversion
-     *          rate between asset2 and the other two assets in the PSM (e.g., sDAI to USD).
+     *          rate between sUSDS and the other two assets in the PSM (e.g., sDAI to USD).
      *  @return The address of the rate provider.
      */
     function rateProvider() external view returns (address);
@@ -133,7 +131,7 @@ interface IPSM3 {
     /**********************************************************************************************/
 
     /**
-     *  @dev    Sets the address of the pocket, an address that holds custody of asset0 in the PSM
+     *  @dev    Sets the address of the pocket, an address that holds custody of USDC in the PSM
      *          and can deploy it to yield-bearing strategies. This function will transfer the
      *          balance of USDC in the PSM to the new pocket. Callable only by the owner.
      *  @param  newPocket Address of the new pocket.
@@ -292,16 +290,16 @@ interface IPSM3 {
      *  @dev    View function that converts an amount of a given shares to the equivalent
      *          amount of assetValue.
      *  @param  numShares  Number of shares to convert to assetValue.
-     *  @return assetValue Value of assets in asset0 denominated in 18 decimals.
+     *  @return assetValue Value of assets in USDC denominated in 18 decimals.
      */
     function convertToAssetValue(uint256 numShares) external view returns (uint256);
 
     /**
      *  @dev    View function that converts an amount of assetValue (18 decimal value denominated in
-     *          asset0 and asset1) to shares in the PSM based on the current exchange rate.
+     *          USDC and USDS) to shares in the PSM based on the current exchange rate.
      *          Note that this rounds down on calculation so is intended to be used for quoting the
      *          current exchange rate.
-     *  @param  assetValue 18 decimal value denominated in asset0 (e.g., 1e6 USDC = 1e18)
+     *  @param  assetValue 18 decimal value denominated in USDC (e.g., 1e6 USDC = 1e18)
      *  @return shares     Number of shares that the assetValue is equivalent to.
      */
     function convertToShares(uint256 assetValue) external view returns (uint256);
@@ -322,7 +320,7 @@ interface IPSM3 {
 
     /**
      *  @dev View function that returns the total value of the balance of all assets in the PSM
-     *       converted to asset0/asset1 terms denominated in 18 decimal precision.
+     *       converted to USDC/USDS terms denominated in 18 decimal precision.
      */
     function totalAssets() external view returns (uint256);
 

--- a/src/interfaces/IPSM3.sol
+++ b/src/interfaces/IPSM3.sol
@@ -88,6 +88,13 @@ interface IPSM3 {
     function asset2() external view returns (IERC20);
 
     /**
+     *  @dev    Returns the address of the pocket, an address that holds custody of USDC in the
+     *          PSM and can deploy it to yield-bearing strategies. Settable by the owner.
+     *  @return The address of the pocket.
+     */
+    function pocket() external view returns (address);
+
+    /**
      *  @dev    Returns the address of the rate provider, a contract that provides the conversion
      *          rate between asset2 and the other two assets in the PSM (e.g., sDAI to USD).
      *  @return The address of the rate provider.

--- a/test/PSMTestBase.sol
+++ b/test/PSMTestBase.sol
@@ -33,9 +33,9 @@ contract PSMTestBase is Test {
     }
 
     // 1,000,000,000,000 of each token
-    uint256 public constant USDC_TOKEN_MAX = 1e18;
-    uint256 public constant SDAI_TOKEN_MAX = 1e30;
     uint256 public constant DAI_TOKEN_MAX  = 1e30;
+    uint256 public constant SDAI_TOKEN_MAX = 1e30;
+    uint256 public constant USDC_TOKEN_MAX = 1e18;
 
     function setUp() public virtual {
         dai  = new MockERC20("dai",  "dai",  18);
@@ -49,7 +49,7 @@ contract PSMTestBase is Test {
 
         rateProvider = IRateProviderLike(address(mockRateProvider));
 
-        psm = new PSM3(owner, address(dai), address(usdc), address(sDai), address(rateProvider));
+        psm = new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
 
         vm.label(address(dai),  "DAI");
         vm.label(address(usdc), "USDC");

--- a/test/PSMTestBase.sol
+++ b/test/PSMTestBase.sol
@@ -13,7 +13,7 @@ import { MockRateProvider } from "test/mocks/MockRateProvider.sol";
 
 contract PSMTestBase is Test {
 
-    address public admin = makeAddr("admin");
+    address public owner = makeAddr("owner");
 
     PSM3 public psm;
 
@@ -49,7 +49,7 @@ contract PSMTestBase is Test {
 
         rateProvider = IRateProviderLike(address(mockRateProvider));
 
-        psm = new PSM3(admin, address(dai), address(usdc), address(sDai), address(rateProvider));
+        psm = new PSM3(owner, address(dai), address(usdc), address(sDai), address(rateProvider));
 
         vm.label(address(dai),  "DAI");
         vm.label(address(usdc), "USDC");

--- a/test/PSMTestBase.sol
+++ b/test/PSMTestBase.sol
@@ -13,6 +13,8 @@ import { MockRateProvider } from "test/mocks/MockRateProvider.sol";
 
 contract PSMTestBase is Test {
 
+    address public admin = makeAddr("admin");
+
     PSM3 public psm;
 
     // NOTE: Using DAI, sDAI and USDC as example assets
@@ -47,7 +49,7 @@ contract PSMTestBase is Test {
 
         rateProvider = IRateProviderLike(address(mockRateProvider));
 
-        psm = new PSM3(address(dai), address(usdc), address(sDai), address(rateProvider));
+        psm = new PSM3(admin, address(dai), address(usdc), address(sDai), address(rateProvider));
 
         vm.label(address(dai),  "DAI");
         vm.label(address(usdc), "USDC");

--- a/test/PSMTestBase.sol
+++ b/test/PSMTestBase.sol
@@ -17,10 +17,9 @@ contract PSMTestBase is Test {
 
     PSM3 public psm;
 
-    // NOTE: Using DAI, sDAI and USDC as example assets
-    MockERC20 public dai;
+    MockERC20 public usds;
     MockERC20 public usdc;
-    MockERC20 public sDai;
+    MockERC20 public susds;
 
     IRateProviderLike public rateProvider;  // Can be overridden by dsrOracle using same interface
 
@@ -33,14 +32,14 @@ contract PSMTestBase is Test {
     }
 
     // 1,000,000,000,000 of each token
-    uint256 public constant DAI_TOKEN_MAX  = 1e30;
-    uint256 public constant SDAI_TOKEN_MAX = 1e30;
-    uint256 public constant USDC_TOKEN_MAX = 1e18;
+    uint256 public constant USDS_TOKEN_MAX  = 1e30;
+    uint256 public constant SUSDS_TOKEN_MAX = 1e30;
+    uint256 public constant USDC_TOKEN_MAX  = 1e18;
 
     function setUp() public virtual {
-        dai  = new MockERC20("dai",  "dai",  18);
-        usdc = new MockERC20("usdc", "usdc", 6);
-        sDai = new MockERC20("sDai", "sDai", 18);
+        usds  = new MockERC20("usds",  "usds",  18);
+        usdc  = new MockERC20("usdc",  "usdc",  6);
+        susds = new MockERC20("susds", "susds", 18);
 
         mockRateProvider = new MockRateProvider();
 
@@ -49,17 +48,17 @@ contract PSMTestBase is Test {
 
         rateProvider = IRateProviderLike(address(mockRateProvider));
 
-        psm = new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
+        psm = new PSM3(owner, address(usdc), address(usds), address(susds), address(rateProvider));
 
-        vm.label(address(dai),  "DAI");
-        vm.label(address(usdc), "USDC");
-        vm.label(address(sDai), "sDAI");
+        vm.label(address(usds),  "USDS");
+        vm.label(address(usdc),  "USDC");
+        vm.label(address(susds), "sUSDS");
     }
 
     function _getPsmValue() internal view returns (uint256) {
-        return (sDai.balanceOf(address(psm)) * rateProvider.getConversionRate() / 1e27)
+        return (susds.balanceOf(address(psm)) * rateProvider.getConversionRate() / 1e27)
             + usdc.balanceOf(address(psm)) * 1e12
-            + dai.balanceOf(address(psm));
+            + usds.balanceOf(address(psm));
     }
 
     function _deposit(address asset, address user, uint256 amount) internal {

--- a/test/invariant/Invariants.t.sol
+++ b/test/invariant/Invariants.t.sol
@@ -94,44 +94,44 @@ abstract contract PSMInvariantTestBase is PSMTestBase {
     }
 
     function _checkInvariant_E() public view {
-        uint256 expectedUsdcInflows = 0;
-        uint256 expectedDaiInflows  = 1e18;  // Seed amount
-        uint256 expectedSDaiInflows = 0;
+        uint256 expectedUsdcInflows  = 0;
+        uint256 expectedUsdsInflows  = 1e18;  // Seed amount
+        uint256 expectedSUsdsInflows = 0;
 
-        uint256 expectedUsdcOutflows = 0;
-        uint256 expectedDaiOutflows  = 0;
-        uint256 expectedSDaiOutflows = 0;
+        uint256 expectedUsdcOutflows  = 0;
+        uint256 expectedUsdsOutflows  = 0;
+        uint256 expectedSUsdsOutflows = 0;
 
         for(uint256 i; i < 3; i++) {
             address lp      = lpHandler.lps(i);
             address swapper = swapperHandler.swappers(i);
 
-            expectedUsdcInflows += lpHandler.lpDeposits(lp, address(usdc));
-            expectedDaiInflows  += lpHandler.lpDeposits(lp, address(usds));
-            expectedSDaiInflows += lpHandler.lpDeposits(lp, address(susds));
+            expectedUsdcInflows  += lpHandler.lpDeposits(lp, address(usdc));
+            expectedUsdsInflows  += lpHandler.lpDeposits(lp, address(usds));
+            expectedSUsdsInflows += lpHandler.lpDeposits(lp, address(susds));
 
-            expectedUsdcInflows += swapperHandler.swapsIn(swapper, address(usdc));
-            expectedDaiInflows  += swapperHandler.swapsIn(swapper, address(usds));
-            expectedSDaiInflows += swapperHandler.swapsIn(swapper, address(susds));
+            expectedUsdcInflows  += swapperHandler.swapsIn(swapper, address(usdc));
+            expectedUsdsInflows  += swapperHandler.swapsIn(swapper, address(usds));
+            expectedSUsdsInflows += swapperHandler.swapsIn(swapper, address(susds));
 
-            expectedUsdcOutflows += lpHandler.lpWithdrawals(lp, address(usdc));
-            expectedDaiOutflows  += lpHandler.lpWithdrawals(lp, address(usds));
-            expectedSDaiOutflows += lpHandler.lpWithdrawals(lp, address(susds));
+            expectedUsdcOutflows  += lpHandler.lpWithdrawals(lp, address(usdc));
+            expectedUsdsOutflows  += lpHandler.lpWithdrawals(lp, address(usds));
+            expectedSUsdsOutflows += lpHandler.lpWithdrawals(lp, address(susds));
 
-            expectedUsdcOutflows += swapperHandler.swapsOut(swapper, address(usdc));
-            expectedDaiOutflows  += swapperHandler.swapsOut(swapper, address(usds));
-            expectedSDaiOutflows += swapperHandler.swapsOut(swapper, address(susds));
+            expectedUsdcOutflows  += swapperHandler.swapsOut(swapper, address(usdc));
+            expectedUsdsOutflows  += swapperHandler.swapsOut(swapper, address(usds));
+            expectedSUsdsOutflows += swapperHandler.swapsOut(swapper, address(susds));
         }
 
         if (address(transferHandler) != address(0)) {
-            expectedUsdcInflows += transferHandler.transfersIn(address(usdc));
-            expectedDaiInflows  += transferHandler.transfersIn(address(usds));
-            expectedSDaiInflows += transferHandler.transfersIn(address(susds));
+            expectedUsdcInflows  += transferHandler.transfersIn(address(usdc));
+            expectedUsdsInflows  += transferHandler.transfersIn(address(usds));
+            expectedSUsdsInflows += transferHandler.transfersIn(address(susds));
         }
 
-        assertEq(usdc.balanceOf(address(psm)), expectedUsdcInflows - expectedUsdcOutflows);
-        assertEq(usds.balanceOf(address(psm)),  expectedDaiInflows  - expectedDaiOutflows);
-        assertEq(susds.balanceOf(address(psm)), expectedSDaiInflows - expectedSDaiOutflows);
+        assertEq(usdc.balanceOf(address(psm)),  expectedUsdcInflows  - expectedUsdcOutflows);
+        assertEq(usds.balanceOf(address(psm)),  expectedUsdsInflows  - expectedUsdsOutflows);
+        assertEq(susds.balanceOf(address(psm)), expectedSUsdsInflows - expectedSUsdsOutflows);
     }
 
     function _checkInvariant_F() public view {

--- a/test/invariant/Invariants.t.sol
+++ b/test/invariant/Invariants.t.sol
@@ -554,7 +554,7 @@ contract PSMInvariants_TimeBasedRateSetting_NoTransfer is PSMInvariantTestBase {
         dsrOracle.revokeRole(dsrOracle.DATA_PROVIDER_ROLE(), address(this));
 
         // Redeploy PSM with new rate provider
-        psm = new PSM3(address(dai), address(usdc), address(sDai), address(dsrOracle));
+        psm = new PSM3(admin, address(dai), address(usdc), address(sDai), address(dsrOracle));
 
         // Seed the new PSM with 1e18 shares (1e18 of value)
         _deposit(address(dai), BURN_ADDRESS, 1e18);
@@ -633,7 +633,7 @@ contract PSMInvariants_TimeBasedRateSetting_WithTransfers is PSMInvariantTestBas
         dsrOracle.revokeRole(dsrOracle.DATA_PROVIDER_ROLE(), address(this));
 
         // Redeploy PSM with new rate provider
-        psm = new PSM3(address(dai), address(usdc), address(sDai), address(dsrOracle));
+        psm = new PSM3(admin, address(dai), address(usdc), address(sDai), address(dsrOracle));
 
         // Seed the new PSM with 1e18 shares (1e18 of value)
         _deposit(address(dai), BURN_ADDRESS, 1e18);

--- a/test/invariant/Invariants.t.sol
+++ b/test/invariant/Invariants.t.sol
@@ -359,8 +359,8 @@ contract PSMInvariants_ConstantRate_NoTransfer is PSMInvariantTestBase {
     function setUp() public override {
         super.setUp();
 
-        lpHandler      = new LpHandler(psm, dai, usdc, sDai, 3);
-        swapperHandler = new SwapperHandler(psm, dai, usdc, sDai, 3);
+        lpHandler      = new LpHandler(psm, usdc, dai, sDai, 3);
+        swapperHandler = new SwapperHandler(psm, usdc, dai, sDai, 3);
 
         targetContract(address(lpHandler));
         targetContract(address(swapperHandler));
@@ -404,9 +404,9 @@ contract PSMInvariants_ConstantRate_WithTransfers is PSMInvariantTestBase {
     function setUp() public override {
         super.setUp();
 
-        lpHandler       = new LpHandler(psm, dai, usdc, sDai, 3);
-        swapperHandler  = new SwapperHandler(psm, dai, usdc, sDai, 3);
-        transferHandler = new TransferHandler(psm, dai, usdc, sDai);
+        lpHandler       = new LpHandler(psm, usdc, dai, sDai, 3);
+        swapperHandler  = new SwapperHandler(psm, usdc, dai, sDai, 3);
+        transferHandler = new TransferHandler(psm, usdc, dai, sDai);
 
         targetContract(address(lpHandler));
         targetContract(address(swapperHandler));
@@ -447,9 +447,9 @@ contract PSMInvariants_RateSetting_NoTransfer is PSMInvariantTestBase {
     function setUp() public override {
         super.setUp();
 
-        lpHandler         = new LpHandler(psm, dai, usdc, sDai, 3);
+        lpHandler         = new LpHandler(psm, usdc, dai, sDai, 3);
         rateSetterHandler = new RateSetterHandler(psm, address(rateProvider), 1.25e27);
-        swapperHandler    = new SwapperHandler(psm, dai, usdc, sDai, 3);
+        swapperHandler    = new SwapperHandler(psm, usdc, dai, sDai, 3);
 
         targetContract(address(lpHandler));
         targetContract(address(rateSetterHandler));
@@ -493,10 +493,10 @@ contract PSMInvariants_RateSetting_WithTransfers is PSMInvariantTestBase {
     function setUp() public override {
         super.setUp();
 
-        lpHandler         = new LpHandler(psm, dai, usdc, sDai, 3);
+        lpHandler         = new LpHandler(psm, usdc, dai, sDai, 3);
         rateSetterHandler = new RateSetterHandler(psm, address(rateProvider), 1.25e27);
-        swapperHandler    = new SwapperHandler(psm, dai, usdc, sDai, 3);
-        transferHandler   = new TransferHandler(psm, dai, usdc, sDai);
+        swapperHandler    = new SwapperHandler(psm, usdc, dai, sDai, 3);
+        transferHandler   = new TransferHandler(psm, usdc, dai, sDai);
 
         targetContract(address(lpHandler));
         targetContract(address(rateSetterHandler));
@@ -554,13 +554,13 @@ contract PSMInvariants_TimeBasedRateSetting_NoTransfer is PSMInvariantTestBase {
         dsrOracle.revokeRole(dsrOracle.DATA_PROVIDER_ROLE(), address(this));
 
         // Redeploy PSM with new rate provider
-        psm = new PSM3(owner, address(dai), address(usdc), address(sDai), address(dsrOracle));
+        psm = new PSM3(owner, address(usdc), address(dai), address(sDai), address(dsrOracle));
 
         // Seed the new PSM with 1e18 shares (1e18 of value)
         _deposit(address(dai), BURN_ADDRESS, 1e18);
 
-        lpHandler            = new LpHandler(psm, dai, usdc, sDai, 3);
-        swapperHandler       = new SwapperHandler(psm, dai, usdc, sDai, 3);
+        lpHandler            = new LpHandler(psm, usdc, dai, sDai, 3);
+        swapperHandler       = new SwapperHandler(psm, usdc, dai, sDai, 3);
         timeBasedRateHandler = new TimeBasedRateHandler(psm, dsrOracle);
 
         // Handler acts in the same way as a receiver on L2, so add as a data provider to the
@@ -580,7 +580,7 @@ contract PSMInvariants_TimeBasedRateSetting_NoTransfer is PSMInvariantTestBase {
         assertEq(swapperHandler.lp0(), lpHandler.lps(0));
     }
 
-    function invariant_A() public view {
+    function invariant_A_test() public view {
         _checkInvariant_A();
     }
 
@@ -633,15 +633,15 @@ contract PSMInvariants_TimeBasedRateSetting_WithTransfers is PSMInvariantTestBas
         dsrOracle.revokeRole(dsrOracle.DATA_PROVIDER_ROLE(), address(this));
 
         // Redeploy PSM with new rate provider
-        psm = new PSM3(owner, address(dai), address(usdc), address(sDai), address(dsrOracle));
+        psm = new PSM3(owner, address(usdc), address(dai), address(sDai), address(dsrOracle));
 
         // Seed the new PSM with 1e18 shares (1e18 of value)
         _deposit(address(dai), BURN_ADDRESS, 1e18);
 
-        lpHandler            = new LpHandler(psm, dai, usdc, sDai, 3);
-        swapperHandler       = new SwapperHandler(psm, dai, usdc, sDai, 3);
+        lpHandler            = new LpHandler(psm, usdc, dai, sDai, 3);
+        swapperHandler       = new SwapperHandler(psm, usdc, dai, sDai, 3);
         timeBasedRateHandler = new TimeBasedRateHandler(psm, dsrOracle);
-        transferHandler      = new TransferHandler(psm, dai, usdc, sDai);
+        transferHandler      = new TransferHandler(psm, usdc, dai, sDai);
 
         // Handler acts in the same way as a receiver on L2, so add as a data provider to the
         // oracle.

--- a/test/invariant/Invariants.t.sol
+++ b/test/invariant/Invariants.t.sol
@@ -554,7 +554,7 @@ contract PSMInvariants_TimeBasedRateSetting_NoTransfer is PSMInvariantTestBase {
         dsrOracle.revokeRole(dsrOracle.DATA_PROVIDER_ROLE(), address(this));
 
         // Redeploy PSM with new rate provider
-        psm = new PSM3(admin, address(dai), address(usdc), address(sDai), address(dsrOracle));
+        psm = new PSM3(owner, address(dai), address(usdc), address(sDai), address(dsrOracle));
 
         // Seed the new PSM with 1e18 shares (1e18 of value)
         _deposit(address(dai), BURN_ADDRESS, 1e18);
@@ -633,7 +633,7 @@ contract PSMInvariants_TimeBasedRateSetting_WithTransfers is PSMInvariantTestBas
         dsrOracle.revokeRole(dsrOracle.DATA_PROVIDER_ROLE(), address(this));
 
         // Redeploy PSM with new rate provider
-        psm = new PSM3(admin, address(dai), address(usdc), address(sDai), address(dsrOracle));
+        psm = new PSM3(owner, address(dai), address(usdc), address(sDai), address(dsrOracle));
 
         // Seed the new PSM with 1e18 shares (1e18 of value)
         _deposit(address(dai), BURN_ADDRESS, 1e18);

--- a/test/invariant/Invariants.t.sol
+++ b/test/invariant/Invariants.t.sol
@@ -35,7 +35,7 @@ abstract contract PSMInvariantTestBase is PSMTestBase {
         super.setUp();
 
         // Seed the pool with 1e18 shares (1e18 of value)
-        _deposit(address(dai), BURN_ADDRESS, 1e18);
+        _deposit(address(usds), BURN_ADDRESS, 1e18);
     }
 
     /**********************************************************************************************/
@@ -107,31 +107,31 @@ abstract contract PSMInvariantTestBase is PSMTestBase {
             address swapper = swapperHandler.swappers(i);
 
             expectedUsdcInflows += lpHandler.lpDeposits(lp, address(usdc));
-            expectedDaiInflows  += lpHandler.lpDeposits(lp, address(dai));
-            expectedSDaiInflows += lpHandler.lpDeposits(lp, address(sDai));
+            expectedDaiInflows  += lpHandler.lpDeposits(lp, address(usds));
+            expectedSDaiInflows += lpHandler.lpDeposits(lp, address(susds));
 
             expectedUsdcInflows += swapperHandler.swapsIn(swapper, address(usdc));
-            expectedDaiInflows  += swapperHandler.swapsIn(swapper, address(dai));
-            expectedSDaiInflows += swapperHandler.swapsIn(swapper, address(sDai));
+            expectedDaiInflows  += swapperHandler.swapsIn(swapper, address(usds));
+            expectedSDaiInflows += swapperHandler.swapsIn(swapper, address(susds));
 
             expectedUsdcOutflows += lpHandler.lpWithdrawals(lp, address(usdc));
-            expectedDaiOutflows  += lpHandler.lpWithdrawals(lp, address(dai));
-            expectedSDaiOutflows += lpHandler.lpWithdrawals(lp, address(sDai));
+            expectedDaiOutflows  += lpHandler.lpWithdrawals(lp, address(usds));
+            expectedSDaiOutflows += lpHandler.lpWithdrawals(lp, address(susds));
 
             expectedUsdcOutflows += swapperHandler.swapsOut(swapper, address(usdc));
-            expectedDaiOutflows  += swapperHandler.swapsOut(swapper, address(dai));
-            expectedSDaiOutflows += swapperHandler.swapsOut(swapper, address(sDai));
+            expectedDaiOutflows  += swapperHandler.swapsOut(swapper, address(usds));
+            expectedSDaiOutflows += swapperHandler.swapsOut(swapper, address(susds));
         }
 
         if (address(transferHandler) != address(0)) {
             expectedUsdcInflows += transferHandler.transfersIn(address(usdc));
-            expectedDaiInflows  += transferHandler.transfersIn(address(dai));
-            expectedSDaiInflows += transferHandler.transfersIn(address(sDai));
+            expectedDaiInflows  += transferHandler.transfersIn(address(usds));
+            expectedSDaiInflows += transferHandler.transfersIn(address(susds));
         }
 
         assertEq(usdc.balanceOf(address(psm)), expectedUsdcInflows - expectedUsdcOutflows);
-        assertEq(dai.balanceOf(address(psm)),  expectedDaiInflows  - expectedDaiOutflows);
-        assertEq(sDai.balanceOf(address(psm)), expectedSDaiInflows - expectedSDaiOutflows);
+        assertEq(usds.balanceOf(address(psm)),  expectedDaiInflows  - expectedDaiOutflows);
+        assertEq(susds.balanceOf(address(psm)), expectedSDaiInflows - expectedSDaiOutflows);
     }
 
     function _checkInvariant_F() public view {
@@ -187,23 +187,23 @@ abstract contract PSMInvariantTestBase is PSMTestBase {
     }
 
     function _getLpTokenValue(address lp) internal view returns (uint256) {
-        uint256 daiValue  = dai.balanceOf(lp);
-        uint256 usdcValue = usdc.balanceOf(lp) * 1e12;
-        uint256 sDaiValue = sDai.balanceOf(lp) * rateProvider.getConversionRate() / 1e27;
+        uint256 usdsValue  = usds.balanceOf(lp);
+        uint256 usdcValue  = usdc.balanceOf(lp) * 1e12;
+        uint256 susdsValue = susds.balanceOf(lp) * rateProvider.getConversionRate() / 1e27;
 
-        return daiValue + usdcValue + sDaiValue;
+        return usdsValue + usdcValue + susdsValue;
     }
 
     function _getLpDepositsValue(address lp) internal view returns (uint256) {
         uint256 depositValue =
-            lpHandler.lpDeposits(lp, address(dai)) +
+            lpHandler.lpDeposits(lp, address(usds)) +
             lpHandler.lpDeposits(lp, address(usdc)) * 1e12 +
-            lpHandler.lpDeposits(lp, address(sDai)) * rateProvider.getConversionRate() / 1e27;
+            lpHandler.lpDeposits(lp, address(susds)) * rateProvider.getConversionRate() / 1e27;
 
         uint256 withdrawValue =
-            lpHandler.lpWithdrawals(lp, address(dai)) +
+            lpHandler.lpWithdrawals(lp, address(usds)) +
             lpHandler.lpWithdrawals(lp, address(usdc)) * 1e12 +
-            lpHandler.lpWithdrawals(lp, address(sDai)) * rateProvider.getConversionRate() / 1e27;
+            lpHandler.lpWithdrawals(lp, address(susds)) * rateProvider.getConversionRate() / 1e27;
 
         return withdrawValue > depositValue ? 0 : depositValue - withdrawValue;
     }
@@ -239,17 +239,17 @@ abstract contract PSMInvariantTestBase is PSMTestBase {
         uint256 startingSeedValue = psm.convertToAssetValue(1e18);
 
         // Liquidity is unknown so withdraw all assets for all users to empty PSM.
-        _withdraw(address(dai),  lp0, type(uint256).max);
-        _withdraw(address(usdc), lp0, type(uint256).max);
-        _withdraw(address(sDai), lp0, type(uint256).max);
+        _withdraw(address(usds),  lp0, type(uint256).max);
+        _withdraw(address(usdc),  lp0, type(uint256).max);
+        _withdraw(address(susds), lp0, type(uint256).max);
 
-        _withdraw(address(dai),  lp1, type(uint256).max);
-        _withdraw(address(usdc), lp1, type(uint256).max);
-        _withdraw(address(sDai), lp1, type(uint256).max);
+        _withdraw(address(usds),  lp1, type(uint256).max);
+        _withdraw(address(usdc),  lp1, type(uint256).max);
+        _withdraw(address(susds), lp1, type(uint256).max);
 
-        _withdraw(address(dai),  lp2, type(uint256).max);
-        _withdraw(address(usdc), lp2, type(uint256).max);
-        _withdraw(address(sDai), lp2, type(uint256).max);
+        _withdraw(address(usds),  lp2, type(uint256).max);
+        _withdraw(address(usdc),  lp2, type(uint256).max);
+        _withdraw(address(susds), lp2, type(uint256).max);
 
         // All funds are completely withdrawn.
         assertEq(psm.shares(lp0), 0);
@@ -297,9 +297,9 @@ abstract contract PSMInvariantTestBase is PSMTestBase {
 
         // NOTE: Below logic is not realistic, shown to demonstrate precision.
 
-        _withdraw(address(dai),  BURN_ADDRESS, type(uint256).max);
-        _withdraw(address(usdc), BURN_ADDRESS, type(uint256).max);
-        _withdraw(address(sDai), BURN_ADDRESS, type(uint256).max);
+        _withdraw(address(usds),  BURN_ADDRESS, type(uint256).max);
+        _withdraw(address(usdc),  BURN_ADDRESS, type(uint256).max);
+        _withdraw(address(susds), BURN_ADDRESS, type(uint256).max);
 
         // When all funds are completely withdrawn, the sum of all funds withdrawn is equal to the
         // sum of value of all LPs including the burn address. All rounding errors get reduced to
@@ -321,9 +321,9 @@ abstract contract PSMInvariantTestBase is PSMTestBase {
         address lp2 = lpHandler.lps(2);
 
         // Ensure that all users have a minimum balance of shares to improve precision
-        _deposit(address(dai), lp0, 100_000e18);
-        _deposit(address(dai), lp1, 100_000e18);
-        _deposit(address(dai), lp2, 100_000e18);
+        _deposit(address(usds), lp0, 100_000e18);
+        _deposit(address(usds), lp1, 100_000e18);
+        _deposit(address(usds), lp2, 100_000e18);
 
         uint256 lp0Value = psm.convertToAssetValue(psm.shares(lp0));
         uint256 lp1Value = psm.convertToAssetValue(psm.shares(lp1));
@@ -359,8 +359,8 @@ contract PSMInvariants_ConstantRate_NoTransfer is PSMInvariantTestBase {
     function setUp() public override {
         super.setUp();
 
-        lpHandler      = new LpHandler(psm, usdc, dai, sDai, 3);
-        swapperHandler = new SwapperHandler(psm, usdc, dai, sDai, 3);
+        lpHandler      = new LpHandler(psm, usdc, usds, susds, 3);
+        swapperHandler = new SwapperHandler(psm, usdc, usds, susds, 3);
 
         targetContract(address(lpHandler));
         targetContract(address(swapperHandler));
@@ -404,9 +404,9 @@ contract PSMInvariants_ConstantRate_WithTransfers is PSMInvariantTestBase {
     function setUp() public override {
         super.setUp();
 
-        lpHandler       = new LpHandler(psm, usdc, dai, sDai, 3);
-        swapperHandler  = new SwapperHandler(psm, usdc, dai, sDai, 3);
-        transferHandler = new TransferHandler(psm, usdc, dai, sDai);
+        lpHandler       = new LpHandler(psm, usdc, usds, susds, 3);
+        swapperHandler  = new SwapperHandler(psm, usdc, usds, susds, 3);
+        transferHandler = new TransferHandler(psm, usdc, usds, susds);
 
         targetContract(address(lpHandler));
         targetContract(address(swapperHandler));
@@ -447,9 +447,9 @@ contract PSMInvariants_RateSetting_NoTransfer is PSMInvariantTestBase {
     function setUp() public override {
         super.setUp();
 
-        lpHandler         = new LpHandler(psm, usdc, dai, sDai, 3);
+        lpHandler         = new LpHandler(psm, usdc, usds, susds, 3);
         rateSetterHandler = new RateSetterHandler(psm, address(rateProvider), 1.25e27);
-        swapperHandler    = new SwapperHandler(psm, usdc, dai, sDai, 3);
+        swapperHandler    = new SwapperHandler(psm, usdc, usds, susds, 3);
 
         targetContract(address(lpHandler));
         targetContract(address(rateSetterHandler));
@@ -493,10 +493,10 @@ contract PSMInvariants_RateSetting_WithTransfers is PSMInvariantTestBase {
     function setUp() public override {
         super.setUp();
 
-        lpHandler         = new LpHandler(psm, usdc, dai, sDai, 3);
+        lpHandler         = new LpHandler(psm, usdc, usds, susds, 3);
         rateSetterHandler = new RateSetterHandler(psm, address(rateProvider), 1.25e27);
-        swapperHandler    = new SwapperHandler(psm, usdc, dai, sDai, 3);
-        transferHandler   = new TransferHandler(psm, usdc, dai, sDai);
+        swapperHandler    = new SwapperHandler(psm, usdc, usds, susds, 3);
+        transferHandler   = new TransferHandler(psm, usdc, usds, susds);
 
         targetContract(address(lpHandler));
         targetContract(address(rateSetterHandler));
@@ -554,13 +554,13 @@ contract PSMInvariants_TimeBasedRateSetting_NoTransfer is PSMInvariantTestBase {
         dsrOracle.revokeRole(dsrOracle.DATA_PROVIDER_ROLE(), address(this));
 
         // Redeploy PSM with new rate provider
-        psm = new PSM3(owner, address(usdc), address(dai), address(sDai), address(dsrOracle));
+        psm = new PSM3(owner, address(usdc), address(usds), address(susds), address(dsrOracle));
 
         // Seed the new PSM with 1e18 shares (1e18 of value)
-        _deposit(address(dai), BURN_ADDRESS, 1e18);
+        _deposit(address(usds), BURN_ADDRESS, 1e18);
 
-        lpHandler            = new LpHandler(psm, usdc, dai, sDai, 3);
-        swapperHandler       = new SwapperHandler(psm, usdc, dai, sDai, 3);
+        lpHandler            = new LpHandler(psm, usdc, usds, susds, 3);
+        swapperHandler       = new SwapperHandler(psm, usdc, usds, susds, 3);
         timeBasedRateHandler = new TimeBasedRateHandler(psm, dsrOracle);
 
         // Handler acts in the same way as a receiver on L2, so add as a data provider to the
@@ -633,15 +633,15 @@ contract PSMInvariants_TimeBasedRateSetting_WithTransfers is PSMInvariantTestBas
         dsrOracle.revokeRole(dsrOracle.DATA_PROVIDER_ROLE(), address(this));
 
         // Redeploy PSM with new rate provider
-        psm = new PSM3(owner, address(usdc), address(dai), address(sDai), address(dsrOracle));
+        psm = new PSM3(owner, address(usdc), address(usds), address(susds), address(dsrOracle));
 
         // Seed the new PSM with 1e18 shares (1e18 of value)
-        _deposit(address(dai), BURN_ADDRESS, 1e18);
+        _deposit(address(usds), BURN_ADDRESS, 1e18);
 
-        lpHandler            = new LpHandler(psm, usdc, dai, sDai, 3);
-        swapperHandler       = new SwapperHandler(psm, usdc, dai, sDai, 3);
+        lpHandler            = new LpHandler(psm, usdc, usds, susds, 3);
+        swapperHandler       = new SwapperHandler(psm, usdc, usds, susds, 3);
         timeBasedRateHandler = new TimeBasedRateHandler(psm, dsrOracle);
-        transferHandler      = new TransferHandler(psm, usdc, dai, sDai);
+        transferHandler      = new TransferHandler(psm, usdc, usds, susds);
 
         // Handler acts in the same way as a receiver on L2, so add as a data provider to the
         // oracle.

--- a/test/invariant/handlers/LpHandler.sol
+++ b/test/invariant/handlers/LpHandler.sol
@@ -19,14 +19,14 @@ contract LpHandler is HandlerBase {
 
     constructor(
         PSM3      psm_,
-        MockERC20 asset0,
-        MockERC20 asset1,
-        MockERC20 asset2,
+        MockERC20 usdc,
+        MockERC20 usds,
+        MockERC20 susds,
         uint256   lpCount
     ) HandlerBase(psm_) {
-        assets[0] = asset0;
-        assets[1] = asset1;
-        assets[2] = asset2;
+        assets[0] = usdc;
+        assets[1] = usds;
+        assets[2] = susds;
 
         for (uint256 i = 0; i < lpCount; i++) {
             lps.push(makeAddr(string(abi.encodePacked("lp-", vm.toString(i)))));

--- a/test/invariant/handlers/SwapperHandler.sol
+++ b/test/invariant/handlers/SwapperHandler.sol
@@ -353,8 +353,8 @@ contract SwapperHandler is HandlerBase {
     }
 
     function _getAssetValue(address asset, uint256 amount) internal view returns (uint256) {
-        if      (asset == address(assets[0])) return amount;
-        else if (asset == address(assets[1])) return amount * 1e12;
+        if      (asset == address(assets[0])) return amount * 1e12;
+        else if (asset == address(assets[1])) return amount;
         else if (asset == address(assets[2])) return amount * rateProvider.getConversionRate() / 1e27;
         else revert("SwapperHandler/asset-not-found");
     }

--- a/test/invariant/handlers/SwapperHandler.sol
+++ b/test/invariant/handlers/SwapperHandler.sol
@@ -30,14 +30,14 @@ contract SwapperHandler is HandlerBase {
 
     constructor(
         PSM3      psm_,
-        MockERC20 asset0,
-        MockERC20 asset1,
-        MockERC20 asset2,
+        MockERC20 usdc,
+        MockERC20 usds,
+        MockERC20 susds,
         uint256   swapperCount
     ) HandlerBase(psm_) {
-        assets[0] = asset0;
-        assets[1] = asset1;
-        assets[2] = asset2;
+        assets[0] = usdc;
+        assets[1] = usds;
+        assets[2] = susds;
 
         rateProvider = IRateProviderLike(psm.rateProvider());
 

--- a/test/invariant/handlers/TransferHandler.sol
+++ b/test/invariant/handlers/TransferHandler.sol
@@ -32,7 +32,6 @@ contract TransferHandler is HandlerBase {
 
     function transfer(uint256 assetSeed, string memory senderSeed, uint256 amount) external {
         // 1. Setup and bounds
-
         MockERC20 asset = _getAsset(assetSeed);
         address   sender = makeAddr(senderSeed);
 

--- a/test/invariant/handlers/TransferHandler.sol
+++ b/test/invariant/handlers/TransferHandler.sol
@@ -17,13 +17,13 @@ contract TransferHandler is HandlerBase {
 
     constructor(
         PSM3      psm_,
-        MockERC20 asset0,
-        MockERC20 asset1,
-        MockERC20 asset2
+        MockERC20 usdc,
+        MockERC20 usds,
+        MockERC20 susds
     ) HandlerBase(psm_) {
-        assets[0] = asset0;
-        assets[1] = asset1;
-        assets[2] = asset2;
+        assets[0] = usdc;
+        assets[1] = usds;
+        assets[2] = susds;
     }
 
     function _getAsset(uint256 indexSeed) internal view returns (MockERC20) {

--- a/test/unit/Constructor.t.sol
+++ b/test/unit/Constructor.t.sol
@@ -20,72 +20,72 @@ contract PSMConstructorTests is PSMTestBase {
 
     function test_constructor_invalidAsset0() public {
         vm.expectRevert("PSM3/invalid-asset0");
-        new PSM3(admin, address(0), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(owner, address(0), address(usdc), address(sDai), address(rateProvider));
     }
 
     function test_constructor_invalidAsset1() public {
         vm.expectRevert("PSM3/invalid-asset1");
-        new PSM3(admin, address(dai), address(0), address(sDai), address(rateProvider));
+        new PSM3(owner, address(dai), address(0), address(sDai), address(rateProvider));
     }
 
     function test_constructor_invalidAsset2() public {
         vm.expectRevert("PSM3/invalid-asset2");
-        new PSM3(admin, address(dai), address(usdc), address(0), address(rateProvider));
+        new PSM3(owner, address(dai), address(usdc), address(0), address(rateProvider));
     }
 
     function test_constructor_invalidRateProvider() public {
         vm.expectRevert("PSM3/invalid-rateProvider");
-        new PSM3(admin, address(dai), address(usdc), address(sDai), address(0));
+        new PSM3(owner, address(dai), address(usdc), address(sDai), address(0));
     }
 
     function test_constructor_asset0Asset1Match() public {
         vm.expectRevert("PSM3/asset0-asset1-same");
-        new PSM3(admin, address(dai), address(dai), address(sDai), address(rateProvider));
+        new PSM3(owner, address(dai), address(dai), address(sDai), address(rateProvider));
     }
 
     function test_constructor_asset0Asset2Match() public {
         vm.expectRevert("PSM3/asset0-asset2-same");
-        new PSM3(admin, address(dai), address(usdc), address(dai), address(rateProvider));
+        new PSM3(owner, address(dai), address(usdc), address(dai), address(rateProvider));
     }
 
     function test_constructor_asset1Asset2Match() public {
         vm.expectRevert("PSM3/asset1-asset2-same");
-        new PSM3(admin, address(dai), address(usdc), address(usdc), address(rateProvider));
+        new PSM3(owner, address(dai), address(usdc), address(usdc), address(rateProvider));
     }
 
     function test_constructor_rateProviderZero() public {
         MockRateProvider(address(rateProvider)).__setConversionRate(0);
         vm.expectRevert("PSM3/rate-provider-returns-zero");
-        new PSM3(admin, address(dai), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(owner, address(dai), address(usdc), address(sDai), address(rateProvider));
     }
 
     function test_constructor_asset0DecimalsToHighBoundary() public {
         MockERC20 asset0 = new MockERC20("Asset0", "A0", 19);
 
         vm.expectRevert("PSM3/asset0-precision-too-high");
-        new PSM3(admin, address(asset0), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(owner, address(asset0), address(usdc), address(sDai), address(rateProvider));
 
         asset0 = new MockERC20("Asset0", "A0", 18);
 
-        new PSM3(admin, address(asset0), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(owner, address(asset0), address(usdc), address(sDai), address(rateProvider));
     }
 
     function test_constructor_asset1DecimalsToHighBoundary() public {
         MockERC20 asset1 = new MockERC20("Asset1", "A1", 19);
 
         vm.expectRevert("PSM3/asset1-precision-too-high");
-        new PSM3(admin, address(dai), address(asset1), address(sDai), address(rateProvider));
+        new PSM3(owner, address(dai), address(asset1), address(sDai), address(rateProvider));
 
         asset1 = new MockERC20("Asset1", "A1", 18);
 
-        new PSM3(admin, address(dai), address(asset1), address(sDai), address(rateProvider));
+        new PSM3(owner, address(dai), address(asset1), address(sDai), address(rateProvider));
     }
 
     function test_constructor() public {
         // Deploy new PSM to get test coverage
-        psm = new PSM3(admin, address(dai), address(usdc), address(sDai), address(rateProvider));
+        psm = new PSM3(owner, address(dai), address(usdc), address(sDai), address(rateProvider));
 
-        assertEq(address(psm.owner()),        address(admin));
+        assertEq(address(psm.owner()),        address(owner));
         assertEq(address(psm.asset0()),       address(dai));
         assertEq(address(psm.asset1()),       address(usdc));
         assertEq(address(psm.asset2()),       address(sDai));

--- a/test/unit/Constructor.t.sol
+++ b/test/unit/Constructor.t.sol
@@ -13,73 +13,79 @@ import { MockRateProvider } from "test/mocks/MockRateProvider.sol";
 
 contract PSMConstructorTests is PSMTestBase {
 
+    function test_constructor_invalidOwner() public {
+        vm.expectRevert(abi.encodeWithSignature("OwnableInvalidOwner(address)", address(0)));
+        new PSM3(address(0), address(dai), address(usdc), address(sDai), address(rateProvider));
+    }
+
     function test_constructor_invalidAsset0() public {
         vm.expectRevert("PSM3/invalid-asset0");
-        new PSM3(address(0), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(admin, address(0), address(usdc), address(sDai), address(rateProvider));
     }
 
     function test_constructor_invalidAsset1() public {
         vm.expectRevert("PSM3/invalid-asset1");
-        new PSM3(address(dai), address(0), address(sDai), address(rateProvider));
+        new PSM3(admin, address(dai), address(0), address(sDai), address(rateProvider));
     }
 
     function test_constructor_invalidAsset2() public {
         vm.expectRevert("PSM3/invalid-asset2");
-        new PSM3(address(dai), address(usdc), address(0), address(rateProvider));
+        new PSM3(admin, address(dai), address(usdc), address(0), address(rateProvider));
     }
 
     function test_constructor_invalidRateProvider() public {
         vm.expectRevert("PSM3/invalid-rateProvider");
-        new PSM3(address(dai), address(usdc), address(sDai), address(0));
+        new PSM3(admin, address(dai), address(usdc), address(sDai), address(0));
     }
 
     function test_constructor_asset0Asset1Match() public {
         vm.expectRevert("PSM3/asset0-asset1-same");
-        new PSM3(address(dai), address(dai), address(sDai), address(rateProvider));
+        new PSM3(admin, address(dai), address(dai), address(sDai), address(rateProvider));
     }
 
     function test_constructor_asset0Asset2Match() public {
         vm.expectRevert("PSM3/asset0-asset2-same");
-        new PSM3(address(dai), address(usdc), address(dai), address(rateProvider));
+        new PSM3(admin, address(dai), address(usdc), address(dai), address(rateProvider));
     }
 
     function test_constructor_asset1Asset2Match() public {
         vm.expectRevert("PSM3/asset1-asset2-same");
-        new PSM3(address(dai), address(usdc), address(usdc), address(rateProvider));
+        new PSM3(admin, address(dai), address(usdc), address(usdc), address(rateProvider));
     }
 
     function test_constructor_rateProviderZero() public {
         MockRateProvider(address(rateProvider)).__setConversionRate(0);
         vm.expectRevert("PSM3/rate-provider-returns-zero");
-        new PSM3(address(dai), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(admin, address(dai), address(usdc), address(sDai), address(rateProvider));
     }
 
     function test_constructor_asset0DecimalsToHighBoundary() public {
         MockERC20 asset0 = new MockERC20("Asset0", "A0", 19);
 
         vm.expectRevert("PSM3/asset0-precision-too-high");
-        new PSM3(address(asset0), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(admin, address(asset0), address(usdc), address(sDai), address(rateProvider));
 
         asset0 = new MockERC20("Asset0", "A0", 18);
 
-        new PSM3(address(asset0), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(admin, address(asset0), address(usdc), address(sDai), address(rateProvider));
     }
 
     function test_constructor_asset1DecimalsToHighBoundary() public {
         MockERC20 asset1 = new MockERC20("Asset1", "A1", 19);
 
         vm.expectRevert("PSM3/asset1-precision-too-high");
-        new PSM3(address(dai), address(asset1), address(sDai), address(rateProvider));
+        new PSM3(admin, address(dai), address(asset1), address(sDai), address(rateProvider));
 
         asset1 = new MockERC20("Asset1", "A1", 18);
 
-        new PSM3(address(dai), address(asset1), address(sDai), address(rateProvider));
+        new PSM3(admin, address(dai), address(asset1), address(sDai), address(rateProvider));
     }
 
     function test_constructor() public {
         // Deploy new PSM to get test coverage
-        psm = new PSM3(address(dai), address(usdc), address(sDai), address(rateProvider));
+        psm = new PSM3(admin, address(dai), address(usdc), address(sDai), address(rateProvider));
 
+        assertEq(address(psm.owner()),        address(admin));
         assertEq(address(psm.asset0()),       address(dai));
         assertEq(address(psm.asset1()),       address(usdc));
         assertEq(address(psm.asset2()),       address(sDai));

--- a/test/unit/Constructor.t.sol
+++ b/test/unit/Constructor.t.sol
@@ -18,18 +18,18 @@ contract PSMConstructorTests is PSMTestBase {
         new PSM3(address(0), address(usdc), address(dai), address(sDai), address(rateProvider));
     }
 
-    function test_constructor_invalidAsset0() public {
-        vm.expectRevert("PSM3/invalid-asset0");
+    function test_constructor_invalidUsdc() public {
+        vm.expectRevert("PSM3/invalid-usdc");
         new PSM3(owner, address(0), address(dai), address(sDai), address(rateProvider));
     }
 
-    function test_constructor_invalidAsset1() public {
-        vm.expectRevert("PSM3/invalid-asset1");
+    function test_constructor_invalidUsds() public {
+        vm.expectRevert("PSM3/invalid-usds");
         new PSM3(owner, address(usdc), address(0), address(sDai), address(rateProvider));
     }
 
-    function test_constructor_invalidAsset2() public {
-        vm.expectRevert("PSM3/invalid-asset2");
+    function test_constructor_invalidSUsds() public {
+        vm.expectRevert("PSM3/invalid-susds");
         new PSM3(owner, address(usdc), address(dai), address(0), address(rateProvider));
     }
 
@@ -38,18 +38,18 @@ contract PSMConstructorTests is PSMTestBase {
         new PSM3(owner, address(usdc), address(dai), address(sDai), address(0));
     }
 
-    function test_constructor_asset0Asset1Match() public {
-        vm.expectRevert("PSM3/asset0-asset1-same");
+    function test_constructor_usdcUsdsMatch() public {
+        vm.expectRevert("PSM3/usdc-usds-same");
         new PSM3(owner, address(usdc), address(usdc), address(sDai), address(rateProvider));
     }
 
-    function test_constructor_asset0Asset2Match() public {
-        vm.expectRevert("PSM3/asset0-asset2-same");
+    function test_constructor_usdcSUsdsMatch() public {
+        vm.expectRevert("PSM3/usdc-susds-same");
         new PSM3(owner, address(usdc), address(dai), address(usdc), address(rateProvider));
     }
 
-    function test_constructor_asset1Asset2Match() public {
-        vm.expectRevert("PSM3/asset1-asset2-same");
+    function test_constructor_usdsSUsdsMatch() public {
+        vm.expectRevert("PSM3/usds-susds-same");
         new PSM3(owner, address(usdc), address(dai), address(dai), address(rateProvider));
     }
 
@@ -59,26 +59,26 @@ contract PSMConstructorTests is PSMTestBase {
         new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
     }
 
-    function test_constructor_asset0DecimalsToHighBoundary() public {
-        MockERC20 asset0 = new MockERC20("Asset0", "A0", 19);
+    function test_constructor_usdcDecimalsToHighBoundary() public {
+        MockERC20 usdc = new MockERC20("USDC", "USDC", 19);
 
-        vm.expectRevert("PSM3/asset0-precision-too-high");
-        new PSM3(owner, address(asset0), address(dai), address(sDai), address(rateProvider));
+        vm.expectRevert("PSM3/usdc-precision-too-high");
+        new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
 
-        asset0 = new MockERC20("Asset0", "A0", 18);
+        usdc = new MockERC20("USDC", "USDC", 18);
 
-        new PSM3(owner, address(asset0), address(dai), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
     }
 
-    function test_constructor_asset1DecimalsToHighBoundary() public {
-        MockERC20 asset1 = new MockERC20("Asset1", "A1", 19);
+    function test_constructor_usdsDecimalsToHighBoundary() public {
+        MockERC20 usds = new MockERC20("USDS", "USDS", 19);
 
-        vm.expectRevert("PSM3/asset1-precision-too-high");
-        new PSM3(owner, address(usdc), address(asset1), address(sDai), address(rateProvider));
+        vm.expectRevert("PSM3/usds-precision-too-high");
+        new PSM3(owner, address(usdc), address(usds), address(sDai), address(rateProvider));
 
-        asset1 = new MockERC20("Asset1", "A1", 18);
+        usds = new MockERC20("USDS", "USDS", 18);
 
-        new PSM3(owner, address(usdc), address(asset1), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usds), address(sDai), address(rateProvider));
     }
 
     function test_constructor() public {
@@ -86,9 +86,9 @@ contract PSMConstructorTests is PSMTestBase {
         psm = new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
 
         assertEq(address(psm.owner()),        address(owner));
-        assertEq(address(psm.asset0()),       address(usdc));
-        assertEq(address(psm.asset1()),       address(dai));
-        assertEq(address(psm.asset2()),       address(sDai));
+        assertEq(address(psm.usdc()),         address(usdc));
+        assertEq(address(psm.usds()),         address(dai));
+        assertEq(address(psm.susds()),        address(sDai));
         assertEq(address(psm.rateProvider()), address(rateProvider));
     }
 

--- a/test/unit/Constructor.t.sol
+++ b/test/unit/Constructor.t.sol
@@ -15,79 +15,79 @@ contract PSMConstructorTests is PSMTestBase {
 
     function test_constructor_invalidOwner() public {
         vm.expectRevert(abi.encodeWithSignature("OwnableInvalidOwner(address)", address(0)));
-        new PSM3(address(0), address(dai), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(address(0), address(usdc), address(dai), address(sDai), address(rateProvider));
     }
 
     function test_constructor_invalidAsset0() public {
         vm.expectRevert("PSM3/invalid-asset0");
-        new PSM3(owner, address(0), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(owner, address(0), address(dai), address(sDai), address(rateProvider));
     }
 
     function test_constructor_invalidAsset1() public {
         vm.expectRevert("PSM3/invalid-asset1");
-        new PSM3(owner, address(dai), address(0), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(0), address(sDai), address(rateProvider));
     }
 
     function test_constructor_invalidAsset2() public {
         vm.expectRevert("PSM3/invalid-asset2");
-        new PSM3(owner, address(dai), address(usdc), address(0), address(rateProvider));
+        new PSM3(owner, address(usdc), address(dai), address(0), address(rateProvider));
     }
 
     function test_constructor_invalidRateProvider() public {
         vm.expectRevert("PSM3/invalid-rateProvider");
-        new PSM3(owner, address(dai), address(usdc), address(sDai), address(0));
+        new PSM3(owner, address(usdc), address(dai), address(sDai), address(0));
     }
 
     function test_constructor_asset0Asset1Match() public {
         vm.expectRevert("PSM3/asset0-asset1-same");
-        new PSM3(owner, address(dai), address(dai), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usdc), address(sDai), address(rateProvider));
     }
 
     function test_constructor_asset0Asset2Match() public {
         vm.expectRevert("PSM3/asset0-asset2-same");
-        new PSM3(owner, address(dai), address(usdc), address(dai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(dai), address(usdc), address(rateProvider));
     }
 
     function test_constructor_asset1Asset2Match() public {
         vm.expectRevert("PSM3/asset1-asset2-same");
-        new PSM3(owner, address(dai), address(usdc), address(usdc), address(rateProvider));
+        new PSM3(owner, address(usdc), address(dai), address(dai), address(rateProvider));
     }
 
     function test_constructor_rateProviderZero() public {
         MockRateProvider(address(rateProvider)).__setConversionRate(0);
         vm.expectRevert("PSM3/rate-provider-returns-zero");
-        new PSM3(owner, address(dai), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
     }
 
     function test_constructor_asset0DecimalsToHighBoundary() public {
         MockERC20 asset0 = new MockERC20("Asset0", "A0", 19);
 
         vm.expectRevert("PSM3/asset0-precision-too-high");
-        new PSM3(owner, address(asset0), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(owner, address(asset0), address(dai), address(sDai), address(rateProvider));
 
         asset0 = new MockERC20("Asset0", "A0", 18);
 
-        new PSM3(owner, address(asset0), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(owner, address(asset0), address(dai), address(sDai), address(rateProvider));
     }
 
     function test_constructor_asset1DecimalsToHighBoundary() public {
         MockERC20 asset1 = new MockERC20("Asset1", "A1", 19);
 
         vm.expectRevert("PSM3/asset1-precision-too-high");
-        new PSM3(owner, address(dai), address(asset1), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(asset1), address(sDai), address(rateProvider));
 
         asset1 = new MockERC20("Asset1", "A1", 18);
 
-        new PSM3(owner, address(dai), address(asset1), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(asset1), address(sDai), address(rateProvider));
     }
 
     function test_constructor() public {
         // Deploy new PSM to get test coverage
-        psm = new PSM3(owner, address(dai), address(usdc), address(sDai), address(rateProvider));
+        psm = new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
 
         assertEq(address(psm.owner()),        address(owner));
-        assertEq(address(psm.asset0()),       address(dai));
-        assertEq(address(psm.asset1()),       address(usdc));
+        assertEq(address(psm.asset0()),       address(usdc));
+        assertEq(address(psm.asset1()),       address(dai));
         assertEq(address(psm.asset2()),       address(sDai));
         assertEq(address(psm.rateProvider()), address(rateProvider));
     }

--- a/test/unit/Constructor.t.sol
+++ b/test/unit/Constructor.t.sol
@@ -15,80 +15,80 @@ contract PSMConstructorTests is PSMTestBase {
 
     function test_constructor_invalidOwner() public {
         vm.expectRevert(abi.encodeWithSignature("OwnableInvalidOwner(address)", address(0)));
-        new PSM3(address(0), address(usdc), address(dai), address(sDai), address(rateProvider));
+        new PSM3(address(0), address(usdc), address(usds), address(susds), address(rateProvider));
     }
 
     function test_constructor_invalidUsdc() public {
         vm.expectRevert("PSM3/invalid-usdc");
-        new PSM3(owner, address(0), address(dai), address(sDai), address(rateProvider));
+        new PSM3(owner, address(0), address(usds), address(susds), address(rateProvider));
     }
 
     function test_constructor_invalidUsds() public {
         vm.expectRevert("PSM3/invalid-usds");
-        new PSM3(owner, address(usdc), address(0), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(0), address(susds), address(rateProvider));
     }
 
     function test_constructor_invalidSUsds() public {
         vm.expectRevert("PSM3/invalid-susds");
-        new PSM3(owner, address(usdc), address(dai), address(0), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usds), address(0), address(rateProvider));
     }
 
     function test_constructor_invalidRateProvider() public {
         vm.expectRevert("PSM3/invalid-rateProvider");
-        new PSM3(owner, address(usdc), address(dai), address(sDai), address(0));
+        new PSM3(owner, address(usdc), address(usds), address(susds), address(0));
     }
 
     function test_constructor_usdcUsdsMatch() public {
         vm.expectRevert("PSM3/usdc-usds-same");
-        new PSM3(owner, address(usdc), address(usdc), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usdc), address(susds), address(rateProvider));
     }
 
     function test_constructor_usdcSUsdsMatch() public {
         vm.expectRevert("PSM3/usdc-susds-same");
-        new PSM3(owner, address(usdc), address(dai), address(usdc), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usds), address(usdc), address(rateProvider));
     }
 
     function test_constructor_usdsSUsdsMatch() public {
         vm.expectRevert("PSM3/usds-susds-same");
-        new PSM3(owner, address(usdc), address(dai), address(dai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usds), address(usds), address(rateProvider));
     }
 
     function test_constructor_rateProviderZero() public {
         MockRateProvider(address(rateProvider)).__setConversionRate(0);
         vm.expectRevert("PSM3/rate-provider-returns-zero");
-        new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usds), address(susds), address(rateProvider));
     }
 
     function test_constructor_usdcDecimalsToHighBoundary() public {
         MockERC20 usdc = new MockERC20("USDC", "USDC", 19);
 
         vm.expectRevert("PSM3/usdc-precision-too-high");
-        new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usds), address(susds), address(rateProvider));
 
         usdc = new MockERC20("USDC", "USDC", 18);
 
-        new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usds), address(susds), address(rateProvider));
     }
 
     function test_constructor_usdsDecimalsToHighBoundary() public {
         MockERC20 usds = new MockERC20("USDS", "USDS", 19);
 
         vm.expectRevert("PSM3/usds-precision-too-high");
-        new PSM3(owner, address(usdc), address(usds), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usds), address(susds), address(rateProvider));
 
         usds = new MockERC20("USDS", "USDS", 18);
 
-        new PSM3(owner, address(usdc), address(usds), address(sDai), address(rateProvider));
+        new PSM3(owner, address(usdc), address(usds), address(susds), address(rateProvider));
     }
 
     function test_constructor() public {
         // Deploy new PSM to get test coverage
-        psm = new PSM3(owner, address(usdc), address(dai), address(sDai), address(rateProvider));
+        psm = new PSM3(owner, address(usdc), address(usds), address(susds), address(rateProvider));
 
         assertEq(address(psm.owner()),        address(owner));
         assertEq(address(psm.usdc()),         address(usdc));
-        assertEq(address(psm.usds()),         address(dai));
-        assertEq(address(psm.susds()),        address(sDai));
+        assertEq(address(psm.usds()),         address(usds));
+        assertEq(address(psm.susds()),        address(susds));
         assertEq(address(psm.rateProvider()), address(rateProvider));
     }
 

--- a/test/unit/Conversions.t.sol
+++ b/test/unit/Conversions.t.sol
@@ -77,19 +77,19 @@ contract PSMConvertToAssetsTests is PSMTestBase {
         assertEq(psm.convertToAssets(address(sDai), 3e18), 2.4e18);
     }
 
-    function testFuzz_convertToAssets_asset0(uint256 amount) public view {
+    function testFuzz_convertToAssets_usdc(uint256 amount) public view {
         amount = _bound(amount, 0, DAI_TOKEN_MAX);
 
         assertEq(psm.convertToAssets(address(dai), amount), amount);
     }
 
-    function testFuzz_convertToAssets_asset1(uint256 amount) public view {
+    function testFuzz_convertToAssets_usds(uint256 amount) public view {
         amount = _bound(amount, 0, USDC_TOKEN_MAX);
 
         assertEq(psm.convertToAssets(address(usdc), amount), amount / 1e12);
     }
 
-    function testFuzz_convertToAssets_asset2(uint256 conversionRate, uint256 amount) public {
+    function testFuzz_convertToAssets_susds(uint256 conversionRate, uint256 amount) public {
         // NOTE: 0.0001e27 considered lower bound for overflow considerations
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);
         amount         = _bound(amount,         0,         SDAI_TOKEN_MAX);

--- a/test/unit/Conversions.t.sol
+++ b/test/unit/Conversions.t.sol
@@ -10,9 +10,9 @@ import { MockRateProvider, PSMTestBase } from "test/PSMTestBase.sol";
 contract PSMConversionTestBase is PSMTestBase {
 
     struct FuzzVars {
-        uint256 daiAmount;
+        uint256 usdsAmount;
         uint256 usdcAmount;
-        uint256 sDaiAmount;
+        uint256 susdsAmount;
         uint256 expectedShares;
     }
 
@@ -20,24 +20,24 @@ contract PSMConversionTestBase is PSMTestBase {
     // initial shares from all deposits (always equal to total value at beginning).
     function _setUpConversionFuzzTest(
         uint256 initialConversionRate,
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount
+        uint256 susdsAmount
     )
         internal returns (FuzzVars memory vars)
     {
-        vars.daiAmount  = _bound(daiAmount,  1, DAI_TOKEN_MAX);
-        vars.usdcAmount = _bound(usdcAmount, 1, USDC_TOKEN_MAX);
-        vars.sDaiAmount = _bound(sDaiAmount, 1, SDAI_TOKEN_MAX);
+        vars.usdsAmount  = _bound(usdsAmount,  1, USDS_TOKEN_MAX);
+        vars.usdcAmount  = _bound(usdcAmount,  1, USDC_TOKEN_MAX);
+        vars.susdsAmount = _bound(susdsAmount, 1, SUSDS_TOKEN_MAX);
 
-        _deposit(address(dai),  address(this), vars.daiAmount);
-        _deposit(address(usdc), address(this), vars.usdcAmount);
-        _deposit(address(sDai), address(this), vars.sDaiAmount);
+        _deposit(address(usds),  address(this), vars.usdsAmount);
+        _deposit(address(usdc),  address(this), vars.usdcAmount);
+        _deposit(address(susds), address(this), vars.susdsAmount);
 
         vars.expectedShares =
-            vars.daiAmount +
+            vars.usdsAmount +
             vars.usdcAmount * 1e12 +
-            vars.sDaiAmount * initialConversionRate / 1e27;
+            vars.susdsAmount * initialConversionRate / 1e27;
 
         // Assert that shares to be used for calcs are correct
         assertEq(psm.totalShares(), vars.expectedShares);
@@ -52,13 +52,13 @@ contract PSMConvertToAssetsTests is PSMTestBase {
     }
 
     function test_convertToAssets() public view {
-        assertEq(psm.convertToAssets(address(dai), 1), 1);
-        assertEq(psm.convertToAssets(address(dai), 2), 2);
-        assertEq(psm.convertToAssets(address(dai), 3), 3);
+        assertEq(psm.convertToAssets(address(usds), 1), 1);
+        assertEq(psm.convertToAssets(address(usds), 2), 2);
+        assertEq(psm.convertToAssets(address(usds), 3), 3);
 
-        assertEq(psm.convertToAssets(address(dai), 1e18), 1e18);
-        assertEq(psm.convertToAssets(address(dai), 2e18), 2e18);
-        assertEq(psm.convertToAssets(address(dai), 3e18), 3e18);
+        assertEq(psm.convertToAssets(address(usds), 1e18), 1e18);
+        assertEq(psm.convertToAssets(address(usds), 2e18), 2e18);
+        assertEq(psm.convertToAssets(address(usds), 3e18), 3e18);
 
         assertEq(psm.convertToAssets(address(usdc), 1), 0);
         assertEq(psm.convertToAssets(address(usdc), 2), 0);
@@ -68,19 +68,19 @@ contract PSMConvertToAssetsTests is PSMTestBase {
         assertEq(psm.convertToAssets(address(usdc), 2e18), 2e6);
         assertEq(psm.convertToAssets(address(usdc), 3e18), 3e6);
 
-        assertEq(psm.convertToAssets(address(sDai), 1), 0);
-        assertEq(psm.convertToAssets(address(sDai), 2), 1);
-        assertEq(psm.convertToAssets(address(sDai), 3), 2);
+        assertEq(psm.convertToAssets(address(susds), 1), 0);
+        assertEq(psm.convertToAssets(address(susds), 2), 1);
+        assertEq(psm.convertToAssets(address(susds), 3), 2);
 
-        assertEq(psm.convertToAssets(address(sDai), 1e18), 0.8e18);
-        assertEq(psm.convertToAssets(address(sDai), 2e18), 1.6e18);
-        assertEq(psm.convertToAssets(address(sDai), 3e18), 2.4e18);
+        assertEq(psm.convertToAssets(address(susds), 1e18), 0.8e18);
+        assertEq(psm.convertToAssets(address(susds), 2e18), 1.6e18);
+        assertEq(psm.convertToAssets(address(susds), 3e18), 2.4e18);
     }
 
     function testFuzz_convertToAssets_usdc(uint256 amount) public view {
-        amount = _bound(amount, 0, DAI_TOKEN_MAX);
+        amount = _bound(amount, 0, USDS_TOKEN_MAX);
 
-        assertEq(psm.convertToAssets(address(dai), amount), amount);
+        assertEq(psm.convertToAssets(address(usds), amount), amount);
     }
 
     function testFuzz_convertToAssets_usds(uint256 amount) public view {
@@ -92,11 +92,11 @@ contract PSMConvertToAssetsTests is PSMTestBase {
     function testFuzz_convertToAssets_susds(uint256 conversionRate, uint256 amount) public {
         // NOTE: 0.0001e27 considered lower bound for overflow considerations
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);
-        amount         = _bound(amount,         0,         SDAI_TOKEN_MAX);
+        amount         = _bound(amount,         0,         SUSDS_TOKEN_MAX);
 
         mockRateProvider.__setConversionRate(conversionRate);
 
-        assertEq(psm.convertToAssets(address(sDai), amount), amount * 1e27 / conversionRate);
+        assertEq(psm.convertToAssets(address(susds), amount), amount * 1e27 / conversionRate);
     }
 
 }
@@ -108,23 +108,23 @@ contract PSMConvertToAssetValueTests is PSMConversionTestBase {
     }
 
     function test_convertToAssetValue() public {
-        _deposit(address(dai),  address(this), 100e18);
+        _deposit(address(usds),  address(this), 100e18);
         _deposit(address(usdc), address(this), 100e6);
-        _deposit(address(sDai), address(this), 80e18);
+        _deposit(address(susds), address(this), 80e18);
 
         assertEq(psm.convertToAssetValue(1e18), 1e18);
 
         mockRateProvider.__setConversionRate(2e27);
 
         // $300 dollars of value deposited, 300 shares minted.
-        // sDAI portion becomes worth $160, full pool worth $360, each share worth $1.20
+        // sUSDS portion becomes worth $160, full pool worth $360, each share worth $1.20
         assertEq(psm.convertToAssetValue(1e18), 1.2e18);
     }
 
     function testFuzz_convertToAssetValue_conversionRateIncrease(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -133,9 +133,9 @@ contract PSMConvertToAssetValueTests is PSMConversionTestBase {
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
             1e27,
-            daiAmount,
+            usdsAmount,
             usdcAmount,
-            sDaiAmount
+            susdsAmount
         );
 
         // These two values are always the same at the beginning
@@ -149,18 +149,18 @@ contract PSMConvertToAssetValueTests is PSMConversionTestBase {
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 newValue
-            = vars.daiAmount + vars.usdcAmount * 1e12 + vars.sDaiAmount * conversionRate / 1e27;
+            = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
         assertEq(psm.convertToAssetValue(vars.expectedShares), newValue);
 
-        // Value change is only from sDAI exchange rate increasing
-        assertEq(newValue - initialValue, vars.sDaiAmount * (conversionRate - 1e27) / 1e27);
+        // Value change is only from sUSDS exchange rate increasing
+        assertEq(newValue - initialValue, vars.susdsAmount * (conversionRate - 1e27) / 1e27);
     }
 
     function testFuzz_convertToAssetValue_conversionRateDecrease(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -169,9 +169,9 @@ contract PSMConvertToAssetValueTests is PSMConversionTestBase {
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
             2e27,
-            daiAmount,
+            usdsAmount,
             usdcAmount,
-            sDaiAmount
+            susdsAmount
         );
 
         // These two values are always the same at the beginning
@@ -185,14 +185,14 @@ contract PSMConvertToAssetValueTests is PSMConversionTestBase {
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 newValue
-            = vars.daiAmount + vars.usdcAmount * 1e12 + vars.sDaiAmount * conversionRate / 1e27;
+            = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
         assertEq(psm.convertToAssetValue(vars.expectedShares), newValue);
 
-        // Value change is only from sDAI exchange rate decreasing
+        // Value change is only from sUSDS exchange rate decreasing
         assertApproxEqAbs(
             initialValue - newValue,
-            vars.sDaiAmount * (2e27 - conversionRate) / 1e27,
+            vars.susdsAmount * (2e27 - conversionRate) / 1e27,
             1
         );
     }
@@ -215,24 +215,24 @@ contract PSMConvertToSharesTests is PSMConversionTestBase {
         _deposit(address(usdc), address(this), 100e6);
         _assertOneToOneConversion();
 
-        _deposit(address(sDai), address(this), 80e18);
+        _deposit(address(susds), address(this), 80e18);
         _assertOneToOneConversion();
 
         _withdraw(address(usdc), address(this), 100e6);
         _assertOneToOneConversion();
 
-        _withdraw(address(sDai), address(this), 80e18);
+        _withdraw(address(susds), address(this), 80e18);
         _assertOneToOneConversion();
     }
 
     function test_convertToShares_conversionRateIncrease() public {
         // 200 shares minted at 1:1 ratio, $200 of value in pool
         _deposit(address(usdc), address(this), 100e6);
-        _deposit(address(sDai), address(this), 80e18);
+        _deposit(address(susds), address(this), 80e18);
 
         _assertOneToOneConversion();
 
-        // 80 sDAI now worth $120, 200 shares in pool with $220 of value
+        // 80 sUSDS now worth $120, 200 shares in pool with $220 of value
         // Each share should be worth $1.10.
         mockRateProvider.__setConversionRate(1.5e27);
 
@@ -246,9 +246,9 @@ contract PSMConvertToSharesTests is PSMConversionTestBase {
     }
 
     function testFuzz_convertToShares_conversionRateIncrease(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -257,9 +257,9 @@ contract PSMConvertToSharesTests is PSMConversionTestBase {
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
             1e27,
-            daiAmount,
+            usdsAmount,
             usdcAmount,
-            sDaiAmount
+            susdsAmount
         );
 
         // These two values are always the same at the beginning
@@ -273,18 +273,18 @@ contract PSMConvertToSharesTests is PSMConversionTestBase {
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 newValue
-            = vars.daiAmount + vars.usdcAmount * 1e12 + vars.sDaiAmount * conversionRate / 1e27;
+            = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
         assertEq(psm.convertToShares(newValue), vars.expectedShares);
 
-        // Value change is only from sDAI exchange rate increasing
-        assertEq(newValue - initialValue, vars.sDaiAmount * (conversionRate - 1e27) / 1e27);
+        // Value change is only from sUSDS exchange rate increasing
+        assertEq(newValue - initialValue, vars.susdsAmount * (conversionRate - 1e27) / 1e27);
     }
 
     function testFuzz_convertToAssetValue_conversionRateDecrease(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -293,9 +293,9 @@ contract PSMConvertToSharesTests is PSMConversionTestBase {
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
             2e27,
-            daiAmount,
+            usdsAmount,
             usdcAmount,
-            sDaiAmount
+            susdsAmount
         );
 
         // These two values are always the same at the beginning
@@ -309,14 +309,14 @@ contract PSMConvertToSharesTests is PSMConversionTestBase {
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 newValue
-            = vars.daiAmount + vars.usdcAmount * 1e12 + vars.sDaiAmount * conversionRate / 1e27;
+            = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
         assertEq(psm.convertToShares(newValue), vars.expectedShares);
 
-        // Value change is only from sDAI exchange rate decreasing
+        // Value change is only from sUSDS exchange rate decreasing
         assertApproxEqAbs(
             initialValue - newValue,
-            vars.sDaiAmount * (2e27 - conversionRate) / 1e27,
+            vars.susdsAmount * (2e27 - conversionRate) / 1e27,
             1
         );
     }
@@ -351,53 +351,53 @@ contract PSMConvertToSharesWithDaiTests is PSMConversionTestBase {
     }
 
     function testFuzz_convertToShares_noValue(uint256 amount) public view {
-        amount = _bound(amount, 0, DAI_TOKEN_MAX);
-        assertEq(psm.convertToShares(address(dai), amount), amount);
+        amount = _bound(amount, 0, USDS_TOKEN_MAX);
+        assertEq(psm.convertToShares(address(usds), amount), amount);
     }
 
     function test_convertToShares_depositAndWithdrawDaiAndSDai_noChange() public {
         _assertOneToOneConversionDai();
 
-        _deposit(address(dai), address(this), 100e18);
+        _deposit(address(usds), address(this), 100e18);
         _assertOneToOneConversionDai();
 
-        _deposit(address(sDai), address(this), 80e18);
+        _deposit(address(susds), address(this), 80e18);
         _assertOneToOneConversionDai();
 
-        _withdraw(address(dai), address(this), 100e18);
+        _withdraw(address(usds), address(this), 100e18);
         _assertOneToOneConversionDai();
 
-        _withdraw(address(sDai), address(this), 80e18);
+        _withdraw(address(susds), address(this), 80e18);
         _assertOneToOneConversionDai();
     }
 
     function test_convertToShares_conversionRateIncrease() public {
         // 200 shares minted at 1:1 ratio, $200 of value in pool
-        _deposit(address(dai),  address(this), 100e18);
-        _deposit(address(sDai), address(this), 80e18);
+        _deposit(address(usds),  address(this), 100e18);
+        _deposit(address(susds), address(this), 80e18);
 
         _assertOneToOneConversionDai();
 
-        // 80 sDAI now worth $120, 200 shares in pool with $220 of value
+        // 80 sUSDS now worth $120, 200 shares in pool with $220 of value
         // Each share should be worth $1.10.
         mockRateProvider.__setConversionRate(1.5e27);
 
-        assertEq(psm.convertToShares(address(dai), 10), 9);
-        assertEq(psm.convertToShares(address(dai), 11), 10);
-        assertEq(psm.convertToShares(address(dai), 12), 10);
+        assertEq(psm.convertToShares(address(usds), 10), 9);
+        assertEq(psm.convertToShares(address(usds), 11), 10);
+        assertEq(psm.convertToShares(address(usds), 12), 10);
 
-        assertEq(psm.convertToShares(address(dai), 10e18), 9.090909090909090909e18);
-        assertEq(psm.convertToShares(address(dai), 11e18), 10e18);
-        assertEq(psm.convertToShares(address(dai), 12e18), 10.909090909090909090e18);
+        assertEq(psm.convertToShares(address(usds), 10e18), 9.090909090909090909e18);
+        assertEq(psm.convertToShares(address(usds), 11e18), 10e18);
+        assertEq(psm.convertToShares(address(usds), 12e18), 10.909090909090909090e18);
     }
 
-    // NOTE: These tests will be the exact same as convertToShares(amount) tests because DAI is an
+    // NOTE: These tests will be the exact same as convertToShares(amount) tests because USDS is an
     //       18 decimal precision asset pegged to the dollar, which is whats used for "value".
 
     function testFuzz_convertToShares_conversionRateIncrease(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -406,9 +406,9 @@ contract PSMConvertToSharesWithDaiTests is PSMConversionTestBase {
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
             1e27,
-            daiAmount,
+            usdsAmount,
             usdcAmount,
-            sDaiAmount
+            susdsAmount
         );
 
         // These two values are always the same at the beginning
@@ -417,23 +417,23 @@ contract PSMConvertToSharesWithDaiTests is PSMConversionTestBase {
         conversionRate = _bound(conversionRate, 1e27, 1000e27);
 
         // 1:1 between shares and dollar value
-        assertEq(psm.convertToShares(address(dai), initialValue), vars.expectedShares);
+        assertEq(psm.convertToShares(address(usds), initialValue), vars.expectedShares);
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 newValue
-            = vars.daiAmount + vars.usdcAmount * 1e12 + vars.sDaiAmount * conversionRate / 1e27;
+            = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
-        assertEq(psm.convertToShares(address(dai), newValue), vars.expectedShares);
+        assertEq(psm.convertToShares(address(usds), newValue), vars.expectedShares);
 
-        // Value change is only from sDAI exchange rate increasing
-        assertEq(newValue - initialValue, vars.sDaiAmount * (conversionRate - 1e27) / 1e27);
+        // Value change is only from sUSDS exchange rate increasing
+        assertEq(newValue - initialValue, vars.susdsAmount * (conversionRate - 1e27) / 1e27);
     }
 
     function testFuzz_convertToAssetValue_conversionRateDecrease(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -442,9 +442,9 @@ contract PSMConvertToSharesWithDaiTests is PSMConversionTestBase {
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
             2e27,
-            daiAmount,
+            usdsAmount,
             usdcAmount,
-            sDaiAmount
+            susdsAmount
         );
 
         // These two values are always the same at the beginning
@@ -453,33 +453,33 @@ contract PSMConvertToSharesWithDaiTests is PSMConversionTestBase {
         conversionRate = _bound(conversionRate, 0.001e27, 2e27);
 
         // 1:1 between shares and dollar value
-        assertEq(psm.convertToShares(address(dai), initialValue), vars.expectedShares);
+        assertEq(psm.convertToShares(address(usds), initialValue), vars.expectedShares);
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 newValue
-            = vars.daiAmount + vars.usdcAmount * 1e12 + vars.sDaiAmount * conversionRate / 1e27;
+            = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
-        assertEq(psm.convertToShares(address(dai), newValue), vars.expectedShares);
+        assertEq(psm.convertToShares(address(usds), newValue), vars.expectedShares);
 
-        // Value change is only from sDAI exchange rate decreasing
+        // Value change is only from sUSDS exchange rate decreasing
         assertApproxEqAbs(
             initialValue - newValue,
-            vars.sDaiAmount * (2e27 - conversionRate) / 1e27,
+            vars.susdsAmount * (2e27 - conversionRate) / 1e27,
             1
         );
     }
 
     function _assertOneToOneConversionDai() internal view {
-        assertEq(psm.convertToShares(address(dai), 1), 1);
-        assertEq(psm.convertToShares(address(dai), 2), 2);
-        assertEq(psm.convertToShares(address(dai), 3), 3);
-        assertEq(psm.convertToShares(address(dai), 4), 4);
+        assertEq(psm.convertToShares(address(usds), 1), 1);
+        assertEq(psm.convertToShares(address(usds), 2), 2);
+        assertEq(psm.convertToShares(address(usds), 3), 3);
+        assertEq(psm.convertToShares(address(usds), 4), 4);
 
-        assertEq(psm.convertToShares(address(dai), 1e18), 1e18);
-        assertEq(psm.convertToShares(address(dai), 2e18), 2e18);
-        assertEq(psm.convertToShares(address(dai), 3e18), 3e18);
-        assertEq(psm.convertToShares(address(dai), 4e18), 4e18);
+        assertEq(psm.convertToShares(address(usds), 1e18), 1e18);
+        assertEq(psm.convertToShares(address(usds), 2e18), 2e18);
+        assertEq(psm.convertToShares(address(usds), 3e18), 3e18);
+        assertEq(psm.convertToShares(address(usds), 4e18), 4e18);
     }
 
 }
@@ -501,24 +501,24 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
         _deposit(address(usdc), address(this), 100e6);
         _assertOneToOneConversionUsdc();
 
-        _deposit(address(sDai), address(this), 80e18);
+        _deposit(address(susds), address(this), 80e18);
         _assertOneToOneConversionUsdc();
 
         _withdraw(address(usdc), address(this), 100e6);
         _assertOneToOneConversionUsdc();
 
-        _withdraw(address(sDai), address(this), 80e18);
+        _withdraw(address(susds), address(this), 80e18);
         _assertOneToOneConversionUsdc();
     }
 
     function test_convertToShares_conversionRateIncrease() public {
         // 200 shares minted at 1:1 ratio, $200 of value in pool
         _deposit(address(usdc), address(this), 100e6);
-        _deposit(address(sDai), address(this), 80e18);
+        _deposit(address(susds), address(this), 80e18);
 
         _assertOneToOneConversionUsdc();
 
-        // 80 sDAI now worth $120, 200 shares in pool with $220 of value
+        // 80 sUSDS now worth $120, 200 shares in pool with $220 of value
         // Each share should be worth $1.10.
         mockRateProvider.__setConversionRate(1.5e27);
 
@@ -532,9 +532,9 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
     }
 
     function testFuzz_convertToShares_conversionRateIncrease(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -543,9 +543,9 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
             1e27,
-            daiAmount,
+            usdsAmount,
             usdcAmount,
-            sDaiAmount
+            susdsAmount
         );
 
         // These two values are always the same at the beginning
@@ -563,7 +563,7 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 newValue
-            = vars.daiAmount + vars.usdcAmount * 1e12 + vars.sDaiAmount * conversionRate / 1e27;
+            = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
         // Larger rounding error because of 1e6 precision
         assertApproxEqAbs(
@@ -584,14 +584,14 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
             (newValue / 1e12 * 1e12) * vars.expectedShares / newValue
         );
 
-        // Value change is only from sDAI exchange rate increasing
-        assertEq(newValue - initialValue, vars.sDaiAmount * (conversionRate - 1e27) / 1e27);
+        // Value change is only from sUSDS exchange rate increasing
+        assertEq(newValue - initialValue, vars.susdsAmount * (conversionRate - 1e27) / 1e27);
     }
 
     function testFuzz_convertToAssetValue_conversionRateDecrease(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -600,9 +600,9 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
             2e27,
-            daiAmount,
+            usdsAmount,
             usdcAmount,
-            sDaiAmount
+            susdsAmount
         );
 
         // These two values are always the same at the beginning
@@ -620,7 +620,7 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 newValue
-            = vars.daiAmount + vars.usdcAmount * 1e12 + vars.sDaiAmount * conversionRate / 1e27;
+            = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
         // Rounding scales with difference between expectedShares and newValue
         assertApproxEqAbs(
@@ -641,10 +641,10 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
             (newValue / 1e12 * 1e12) * vars.expectedShares / newValue
         );
 
-        // Value change is only from sDAI exchange rate decreasing
+        // Value change is only from sUSDS exchange rate decreasing
         assertApproxEqAbs(
             initialValue - newValue,
-            vars.sDaiAmount * (2e27 - conversionRate) / 1e27,
+            vars.susdsAmount * (2e27 - conversionRate) / 1e27,
             1
         );
     }
@@ -670,12 +670,12 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
     }
 
     function testFuzz_convertToShares_noValue(uint256 amount, uint256 conversionRate) public {
-        amount         = _bound(amount,         1000,    SDAI_TOKEN_MAX);
+        amount         = _bound(amount,         1000,    SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.01e27, 1000e27);
 
         mockRateProvider.__setConversionRate(conversionRate);
 
-        assertEq(psm.convertToShares(address(sDai), amount), amount * conversionRate / 1e27);
+        assertEq(psm.convertToShares(address(susds), amount), amount * conversionRate / 1e27);
     }
 
     function test_convertToShares_depositAndWithdrawUsdcAndSDai_noChange() public {
@@ -684,43 +684,43 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
         _deposit(address(usdc), address(this), 100e6);
         _assertStartingConversionSDai();
 
-        _deposit(address(sDai), address(this), 80e18);
+        _deposit(address(susds), address(this), 80e18);
         _assertStartingConversionSDai();
 
         _withdraw(address(usdc), address(this), 100e6);
         _assertStartingConversionSDai();
 
-        _withdraw(address(sDai), address(this), 80e18);
+        _withdraw(address(susds), address(this), 80e18);
         _assertStartingConversionSDai();
     }
 
     function test_convertToShares_conversionRateIncrease() public {
         // 200 shares minted at 1:1 ratio, $200 of value in pool
         _deposit(address(usdc), address(this), 100e6);
-        _deposit(address(sDai), address(this), 80e18);
+        _deposit(address(susds), address(this), 80e18);
 
         _assertStartingConversionSDai();
 
-        // 80 sDAI now worth $120, 200 shares in pool with $220 of value
-        // Each share should be worth $1.10. Since 1 sDAI is now worth 1.5 USDC, 1 sDAI is worth
+        // 80 sUSDS now worth $120, 200 shares in pool with $220 of value
+        // Each share should be worth $1.10. Since 1 sUSDS is now worth 1.5 USDC, 1 sUSDS is worth
         // 1.50/1.10 = 1.3636... shares
         mockRateProvider.__setConversionRate(1.5e27);
 
-        assertEq(psm.convertToShares(address(sDai), 1), 0);
-        assertEq(psm.convertToShares(address(sDai), 2), 2);
-        assertEq(psm.convertToShares(address(sDai), 3), 3);  // 3 * 1.5 / 1.1 = 3 because of rounding on first operation
-        assertEq(psm.convertToShares(address(sDai), 4), 5);
+        assertEq(psm.convertToShares(address(susds), 1), 0);
+        assertEq(psm.convertToShares(address(susds), 2), 2);
+        assertEq(psm.convertToShares(address(susds), 3), 3);  // 3 * 1.5 / 1.1 = 3 because of rounding on first operation
+        assertEq(psm.convertToShares(address(susds), 4), 5);
 
-        assertEq(psm.convertToShares(address(sDai), 1e18), 1.363636363636363636e18);
-        assertEq(psm.convertToShares(address(sDai), 2e18), 2.727272727272727272e18);
-        assertEq(psm.convertToShares(address(sDai), 3e18), 4.090909090909090909e18);
-        assertEq(psm.convertToShares(address(sDai), 4e18), 5.454545454545454545e18);
+        assertEq(psm.convertToShares(address(susds), 1e18), 1.363636363636363636e18);
+        assertEq(psm.convertToShares(address(susds), 2e18), 2.727272727272727272e18);
+        assertEq(psm.convertToShares(address(susds), 3e18), 4.090909090909090909e18);
+        assertEq(psm.convertToShares(address(susds), 4e18), 5.454545454545454545e18);
     }
 
     function testFuzz_convertToShares_conversionRateIncrease(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -730,9 +730,9 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
             1.1e27,
-            daiAmount,
+            usdsAmount,
             usdcAmount,
-            sDaiAmount
+            susdsAmount
         );
 
         // These two values are always the same at the beginning
@@ -743,7 +743,7 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
 
         // 1:1 between shares and dollar value
         assertApproxEqAbs(
-            psm.convertToShares(address(sDai), initialSDaiValue),
+            psm.convertToShares(address(susds), initialSDaiValue),
             vars.expectedShares,
             1
         );
@@ -751,41 +751,41 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 newValue
-            = vars.daiAmount + vars.usdcAmount * 1e12 + vars.sDaiAmount * conversionRate / 1e27;
+            = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
         uint256 newSDaiValue = newValue * 1e27 / conversionRate;
 
-        // Depositing derived sDAI amount yields the same amount of shares (approx)
+        // Depositing derived sUSDS amount yields the same amount of shares (approx)
         assertApproxEqAbs(
-            psm.convertToShares(address(sDai), newSDaiValue),
+            psm.convertToShares(address(susds), newSDaiValue),
             vars.expectedShares,
             1000
         );
 
         // Make sure that rounding error here is always against the user
         assertLe(
-            psm.convertToShares(address(sDai), newSDaiValue),
+            psm.convertToShares(address(susds), newSDaiValue),
             vars.expectedShares
         );
 
         // This is the exact calculation of what is happening
         assertEq(
-            psm.convertToShares(address(sDai), newSDaiValue),
+            psm.convertToShares(address(susds), newSDaiValue),
             (newSDaiValue * conversionRate / 1e27) * vars.expectedShares / newValue
         );
 
-        // Value change is only from sDAI exchange rate increasing
+        // Value change is only from sUSDS exchange rate increasing
         assertApproxEqAbs(
             newValue - initialValue,
-            vars.sDaiAmount * (conversionRate - 1.1e27) / 1e27,
+            vars.susdsAmount * (conversionRate - 1.1e27) / 1e27,
             3
         );
     }
 
     function testFuzz_convertToAssetValue_conversionRateDecrease(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -794,9 +794,9 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
             2e27,
-            daiAmount,
+            usdsAmount,
             usdcAmount,
-            sDaiAmount
+            susdsAmount
         );
 
         // These two values are always the same at the beginning
@@ -807,7 +807,7 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
 
         // 1:1 between shares and dollar value
         assertApproxEqAbs(
-            psm.convertToShares(address(sDai), initialSDaiValue),
+            psm.convertToShares(address(susds), initialSDaiValue),
             vars.expectedShares,
             1
         );
@@ -815,33 +815,33 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 newValue
-            = vars.daiAmount + vars.usdcAmount * 1e12 + vars.sDaiAmount * conversionRate / 1e27;
+            = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
         uint256 newSDaiValue = newValue * 1e27 / conversionRate;
 
-        // Depositing derived sDAI amount yields the same amount of shares (approx)
+        // Depositing derived sUSDS amount yields the same amount of shares (approx)
         assertApproxEqAbs(
-            psm.convertToShares(address(sDai), newSDaiValue),
+            psm.convertToShares(address(susds), newSDaiValue),
             vars.expectedShares,
             2000
         );
 
         // Make sure that rounding error here is always against the user
         assertLe(
-            psm.convertToShares(address(sDai), newSDaiValue),
+            psm.convertToShares(address(susds), newSDaiValue),
             vars.expectedShares
         );
 
         // This is the exact calculation of what is happening
         assertEq(
-            psm.convertToShares(address(sDai), newSDaiValue),
+            psm.convertToShares(address(susds), newSDaiValue),
             (newSDaiValue * conversionRate / 1e27) * vars.expectedShares / newValue
         );
 
-        // Value change is only from sDAI exchange rate increasing
+        // Value change is only from sUSDS exchange rate increasing
         assertApproxEqAbs(
             initialValue - newValue,
-            vars.sDaiAmount * (2e27 - conversionRate) / 1e27,
+            vars.susdsAmount * (2e27 - conversionRate) / 1e27,
             3
         );
     }
@@ -858,17 +858,17 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
         assertEq(psm.convertToShares(4e18), 4e18);
     }
 
-    // NOTE: This is different because the dollar value of sDAI is 1.25x that of USDC
+    // NOTE: This is different because the dollar value of sUSDS is 1.25x that of USDC
     function _assertStartingConversionSDai() internal view {
-        assertEq(psm.convertToShares(address(sDai), 1), 1);
-        assertEq(psm.convertToShares(address(sDai), 2), 2);
-        assertEq(psm.convertToShares(address(sDai), 3), 3);
-        assertEq(psm.convertToShares(address(sDai), 4), 5);
+        assertEq(psm.convertToShares(address(susds), 1), 1);
+        assertEq(psm.convertToShares(address(susds), 2), 2);
+        assertEq(psm.convertToShares(address(susds), 3), 3);
+        assertEq(psm.convertToShares(address(susds), 4), 5);
 
-        assertEq(psm.convertToShares(address(sDai), 1e18), 1.25e18);
-        assertEq(psm.convertToShares(address(sDai), 2e18), 2.5e18);
-        assertEq(psm.convertToShares(address(sDai), 3e18), 3.75e18);
-        assertEq(psm.convertToShares(address(sDai), 4e18), 5e18);
+        assertEq(psm.convertToShares(address(susds), 1e18), 1.25e18);
+        assertEq(psm.convertToShares(address(susds), 2e18), 2.5e18);
+        assertEq(psm.convertToShares(address(susds), 3e18), 3.75e18);
+        assertEq(psm.convertToShares(address(susds), 4e18), 5e18);
     }
 
 }

--- a/test/unit/Conversions.t.sol
+++ b/test/unit/Conversions.t.sol
@@ -109,7 +109,7 @@ contract PSMConvertToAssetValueTests is PSMConversionTestBase {
 
     function test_convertToAssetValue() public {
         _deposit(address(usds),  address(this), 100e18);
-        _deposit(address(usdc), address(this), 100e6);
+        _deposit(address(usdc),  address(this), 100e6);
         _deposit(address(susds), address(this), 80e18);
 
         assertEq(psm.convertToAssetValue(1e18), 1e18);
@@ -209,7 +209,7 @@ contract PSMConvertToSharesTests is PSMConversionTestBase {
         assertEq(psm.convertToShares(amount), amount);
     }
 
-    function test_convertToShares_depositAndWithdrawUsdcAndSDai_noChange() public {
+    function test_convertToShares_depositAndWithdrawUsdcAndSUsds_noChange() public {
         _assertOneToOneConversion();
 
         _deposit(address(usdc), address(this), 100e6);
@@ -344,10 +344,10 @@ contract PSMConvertToSharesFailureTests is PSMTestBase {
 
 }
 
-contract PSMConvertToSharesWithDaiTests is PSMConversionTestBase {
+contract PSMConvertToSharesWithUsdsTests is PSMConversionTestBase {
 
     function test_convertToShares_noValue() public view {
-        _assertOneToOneConversionDai();
+        _assertOneToOneConversionUsds();
     }
 
     function testFuzz_convertToShares_noValue(uint256 amount) public view {
@@ -355,20 +355,20 @@ contract PSMConvertToSharesWithDaiTests is PSMConversionTestBase {
         assertEq(psm.convertToShares(address(usds), amount), amount);
     }
 
-    function test_convertToShares_depositAndWithdrawDaiAndSDai_noChange() public {
-        _assertOneToOneConversionDai();
+    function test_convertToShares_depositAndWithdrawUsdsAndSUsds_noChange() public {
+        _assertOneToOneConversionUsds();
 
         _deposit(address(usds), address(this), 100e18);
-        _assertOneToOneConversionDai();
+        _assertOneToOneConversionUsds();
 
         _deposit(address(susds), address(this), 80e18);
-        _assertOneToOneConversionDai();
+        _assertOneToOneConversionUsds();
 
         _withdraw(address(usds), address(this), 100e18);
-        _assertOneToOneConversionDai();
+        _assertOneToOneConversionUsds();
 
         _withdraw(address(susds), address(this), 80e18);
-        _assertOneToOneConversionDai();
+        _assertOneToOneConversionUsds();
     }
 
     function test_convertToShares_conversionRateIncrease() public {
@@ -376,7 +376,7 @@ contract PSMConvertToSharesWithDaiTests is PSMConversionTestBase {
         _deposit(address(usds),  address(this), 100e18);
         _deposit(address(susds), address(this), 80e18);
 
-        _assertOneToOneConversionDai();
+        _assertOneToOneConversionUsds();
 
         // 80 sUSDS now worth $120, 200 shares in pool with $220 of value
         // Each share should be worth $1.10.
@@ -470,7 +470,7 @@ contract PSMConvertToSharesWithDaiTests is PSMConversionTestBase {
         );
     }
 
-    function _assertOneToOneConversionDai() internal view {
+    function _assertOneToOneConversionUsds() internal view {
         assertEq(psm.convertToShares(address(usds), 1), 1);
         assertEq(psm.convertToShares(address(usds), 2), 2);
         assertEq(psm.convertToShares(address(usds), 3), 3);
@@ -495,7 +495,7 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
         assertEq(psm.convertToShares(address(usdc), amount), amount * 1e12);
     }
 
-    function test_convertToShares_depositAndWithdrawUsdcAndSDai_noChange() public {
+    function test_convertToShares_depositAndWithdrawUsdcAndSUsds_noChange() public {
         _assertOneToOneConversionUsdc();
 
         _deposit(address(usdc), address(this), 100e6);
@@ -513,7 +513,7 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
 
     function test_convertToShares_conversionRateIncrease() public {
         // 200 shares minted at 1:1 ratio, $200 of value in pool
-        _deposit(address(usdc), address(this), 100e6);
+        _deposit(address(usdc),  address(this), 100e6);
         _deposit(address(susds), address(this), 80e18);
 
         _assertOneToOneConversionUsdc();
@@ -663,7 +663,7 @@ contract PSMConvertToSharesWithUsdcTests is PSMConversionTestBase {
 
 }
 
-contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
+contract PSMConvertToSharesWithSUsdsTests is PSMConversionTestBase {
 
     function test_convertToShares_noValue() public view {
         _assertOneToOneConversion();
@@ -678,20 +678,20 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
         assertEq(psm.convertToShares(address(susds), amount), amount * conversionRate / 1e27);
     }
 
-    function test_convertToShares_depositAndWithdrawUsdcAndSDai_noChange() public {
+    function test_convertToShares_depositAndWithdrawUsdcAndSUsds_noChange() public {
         _assertOneToOneConversion();
 
         _deposit(address(usdc), address(this), 100e6);
-        _assertStartingConversionSDai();
+        _assertStartingConversionSUsds();
 
         _deposit(address(susds), address(this), 80e18);
-        _assertStartingConversionSDai();
+        _assertStartingConversionSUsds();
 
         _withdraw(address(usdc), address(this), 100e6);
-        _assertStartingConversionSDai();
+        _assertStartingConversionSUsds();
 
         _withdraw(address(susds), address(this), 80e18);
-        _assertStartingConversionSDai();
+        _assertStartingConversionSUsds();
     }
 
     function test_convertToShares_conversionRateIncrease() public {
@@ -699,7 +699,7 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
         _deposit(address(usdc), address(this), 100e6);
         _deposit(address(susds), address(this), 80e18);
 
-        _assertStartingConversionSDai();
+        _assertStartingConversionSUsds();
 
         // 80 sUSDS now worth $120, 200 shares in pool with $220 of value
         // Each share should be worth $1.10. Since 1 sUSDS is now worth 1.5 USDC, 1 sUSDS is worth
@@ -725,7 +725,7 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
     )
         public
     {
-        // NOTE: Not using 1e27 for this test because initialSDaiValue needs to be different
+        // NOTE: Not using 1e27 for this test because initialSUsdsValue needs to be different
         mockRateProvider.__setConversionRate(1.1e27);  // Start lower than 1.25 for this test
 
         FuzzVars memory vars = _setUpConversionFuzzTest(
@@ -737,13 +737,13 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
 
         // These two values are always the same at the beginning
         uint256 initialValue     = vars.expectedShares;
-        uint256 initialSDaiValue = initialValue * 1e27 / 1.1e27;
+        uint256 initialSUsdsValue = initialValue * 1e27 / 1.1e27;
 
         conversionRate = _bound(conversionRate, 1.1e27, 1000e27);
 
         // 1:1 between shares and dollar value
         assertApproxEqAbs(
-            psm.convertToShares(address(susds), initialSDaiValue),
+            psm.convertToShares(address(susds), initialSUsdsValue),
             vars.expectedShares,
             1
         );
@@ -753,25 +753,25 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
         uint256 newValue
             = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
-        uint256 newSDaiValue = newValue * 1e27 / conversionRate;
+        uint256 newSUsdsValue = newValue * 1e27 / conversionRate;
 
         // Depositing derived sUSDS amount yields the same amount of shares (approx)
         assertApproxEqAbs(
-            psm.convertToShares(address(susds), newSDaiValue),
+            psm.convertToShares(address(susds), newSUsdsValue),
             vars.expectedShares,
             1000
         );
 
         // Make sure that rounding error here is always against the user
         assertLe(
-            psm.convertToShares(address(susds), newSDaiValue),
+            psm.convertToShares(address(susds), newSUsdsValue),
             vars.expectedShares
         );
 
         // This is the exact calculation of what is happening
         assertEq(
-            psm.convertToShares(address(susds), newSDaiValue),
-            (newSDaiValue * conversionRate / 1e27) * vars.expectedShares / newValue
+            psm.convertToShares(address(susds), newSUsdsValue),
+            (newSUsdsValue * conversionRate / 1e27) * vars.expectedShares / newValue
         );
 
         // Value change is only from sUSDS exchange rate increasing
@@ -800,14 +800,14 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
         );
 
         // These two values are always the same at the beginning
-        uint256 initialValue     = vars.expectedShares;
-        uint256 initialSDaiValue = initialValue * 1e27 / 2e27;
+        uint256 initialValue      = vars.expectedShares;
+        uint256 initialSUsdsValue = initialValue * 1e27 / 2e27;
 
         conversionRate = _bound(conversionRate, 0.001e27, 2e27);
 
         // 1:1 between shares and dollar value
         assertApproxEqAbs(
-            psm.convertToShares(address(susds), initialSDaiValue),
+            psm.convertToShares(address(susds), initialSUsdsValue),
             vars.expectedShares,
             1
         );
@@ -817,25 +817,25 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
         uint256 newValue
             = vars.usdsAmount + vars.usdcAmount * 1e12 + vars.susdsAmount * conversionRate / 1e27;
 
-        uint256 newSDaiValue = newValue * 1e27 / conversionRate;
+        uint256 newSUsdsValue = newValue * 1e27 / conversionRate;
 
         // Depositing derived sUSDS amount yields the same amount of shares (approx)
         assertApproxEqAbs(
-            psm.convertToShares(address(susds), newSDaiValue),
+            psm.convertToShares(address(susds), newSUsdsValue),
             vars.expectedShares,
             2000
         );
 
         // Make sure that rounding error here is always against the user
         assertLe(
-            psm.convertToShares(address(susds), newSDaiValue),
+            psm.convertToShares(address(susds), newSUsdsValue),
             vars.expectedShares
         );
 
         // This is the exact calculation of what is happening
         assertEq(
-            psm.convertToShares(address(susds), newSDaiValue),
-            (newSDaiValue * conversionRate / 1e27) * vars.expectedShares / newValue
+            psm.convertToShares(address(susds), newSUsdsValue),
+            (newSUsdsValue * conversionRate / 1e27) * vars.expectedShares / newValue
         );
 
         // Value change is only from sUSDS exchange rate increasing
@@ -859,7 +859,7 @@ contract PSMConvertToSharesWithSDaiTests is PSMConversionTestBase {
     }
 
     // NOTE: This is different because the dollar value of sUSDS is 1.25x that of USDC
-    function _assertStartingConversionSDai() internal view {
+    function _assertStartingConversionSUsds() internal view {
         assertEq(psm.convertToShares(address(susds), 1), 1);
         assertEq(psm.convertToShares(address(susds), 2), 2);
         assertEq(psm.convertToShares(address(susds), 3), 3);

--- a/test/unit/Deployment.t.sol
+++ b/test/unit/Deployment.t.sol
@@ -23,9 +23,9 @@ contract PSMDeployTests is PSMTestBase {
         ));
 
         assertEq(address(newPsm.owner()),        address(owner));
-        assertEq(address(newPsm.asset0()),       address(usdc));
-        assertEq(address(newPsm.asset1()),       address(dai));
-        assertEq(address(newPsm.asset2()),       address(sDai));
+        assertEq(address(newPsm.usdc()),         address(usdc));
+        assertEq(address(newPsm.usds()),         address(dai));
+        assertEq(address(newPsm.susds()),        address(sDai));
         assertEq(address(newPsm.rateProvider()), address(rateProvider));
 
         assertEq(dai.allowance(address(this), address(newPsm)), 0);

--- a/test/unit/Deployment.t.sol
+++ b/test/unit/Deployment.t.sol
@@ -15,14 +15,14 @@ contract PSMDeployTests is PSMTestBase {
         deal(address(dai), address(this), 1e18);
 
         PSM3 newPsm = PSM3(PSM3Deploy.deploy(
-            address(admin),
+            address(owner),
             address(dai),
             address(usdc),
             address(sDai),
             address(rateProvider)
         ));
 
-        assertEq(address(newPsm.owner()),        address(admin));
+        assertEq(address(newPsm.owner()),        address(owner));
         assertEq(address(newPsm.asset0()),       address(dai));
         assertEq(address(newPsm.asset1()),       address(usdc));
         assertEq(address(newPsm.asset2()),       address(sDai));

--- a/test/unit/Deployment.t.sol
+++ b/test/unit/Deployment.t.sol
@@ -16,15 +16,15 @@ contract PSMDeployTests is PSMTestBase {
 
         PSM3 newPsm = PSM3(PSM3Deploy.deploy(
             address(owner),
-            address(dai),
             address(usdc),
+            address(dai),
             address(sDai),
             address(rateProvider)
         ));
 
         assertEq(address(newPsm.owner()),        address(owner));
-        assertEq(address(newPsm.asset0()),       address(dai));
-        assertEq(address(newPsm.asset1()),       address(usdc));
+        assertEq(address(newPsm.asset0()),       address(usdc));
+        assertEq(address(newPsm.asset1()),       address(dai));
         assertEq(address(newPsm.asset2()),       address(sDai));
         assertEq(address(newPsm.rateProvider()), address(rateProvider));
 

--- a/test/unit/Deployment.t.sol
+++ b/test/unit/Deployment.t.sol
@@ -12,26 +12,26 @@ import { PSMTestBase } from "test/PSMTestBase.sol";
 contract PSMDeployTests is PSMTestBase {
 
     function test_deploy() public {
-        deal(address(dai), address(this), 1e18);
+        deal(address(usds), address(this), 1e18);
 
         PSM3 newPsm = PSM3(PSM3Deploy.deploy(
             address(owner),
             address(usdc),
-            address(dai),
-            address(sDai),
+            address(usds),
+            address(susds),
             address(rateProvider)
         ));
 
         assertEq(address(newPsm.owner()),        address(owner));
         assertEq(address(newPsm.usdc()),         address(usdc));
-        assertEq(address(newPsm.usds()),         address(dai));
-        assertEq(address(newPsm.susds()),        address(sDai));
+        assertEq(address(newPsm.usds()),         address(usds));
+        assertEq(address(newPsm.susds()),        address(susds));
         assertEq(address(newPsm.rateProvider()), address(rateProvider));
 
-        assertEq(dai.allowance(address(this), address(newPsm)), 0);
+        assertEq(usds.allowance(address(this), address(newPsm)), 0);
 
-        assertEq(dai.balanceOf(address(this)),   0);
-        assertEq(dai.balanceOf(address(newPsm)), 1e18);
+        assertEq(usds.balanceOf(address(this)),   0);
+        assertEq(usds.balanceOf(address(newPsm)), 1e18);
 
         assertEq(newPsm.totalAssets(),         1e18);
         assertEq(newPsm.totalShares(),         1e18);

--- a/test/unit/Deployment.t.sol
+++ b/test/unit/Deployment.t.sol
@@ -15,12 +15,14 @@ contract PSMDeployTests is PSMTestBase {
         deal(address(dai), address(this), 1e18);
 
         PSM3 newPsm = PSM3(PSM3Deploy.deploy(
+            address(admin),
             address(dai),
             address(usdc),
             address(sDai),
             address(rateProvider)
         ));
 
+        assertEq(address(newPsm.owner()),        address(admin));
         assertEq(address(newPsm.asset0()),       address(dai));
         assertEq(address(newPsm.asset1()),       address(usdc));
         assertEq(address(newPsm.asset2()),       address(sDai));

--- a/test/unit/Deposit.t.sol
+++ b/test/unit/Deposit.t.sol
@@ -25,45 +25,45 @@ contract PSMDepositTests is PSMTestBase {
     }
 
     function test_deposit_insufficientApproveBoundary() public {
-        dai.mint(user1, 100e18);
+        usds.mint(user1, 100e18);
 
         vm.startPrank(user1);
 
-        dai.approve(address(psm), 100e18 - 1);
+        usds.approve(address(psm), 100e18 - 1);
 
         vm.expectRevert("SafeERC20/transfer-from-failed");
-        psm.deposit(address(dai), user1, 100e18);
+        psm.deposit(address(usds), user1, 100e18);
 
-        dai.approve(address(psm), 100e18);
+        usds.approve(address(psm), 100e18);
 
-        psm.deposit(address(dai), user1, 100e18);
+        psm.deposit(address(usds), user1, 100e18);
     }
 
     function test_deposit_insufficientBalanceBoundary() public {
-        dai.mint(user1, 100e18 - 1);
+        usds.mint(user1, 100e18 - 1);
 
         vm.startPrank(user1);
 
-        dai.approve(address(psm), 100e18);
+        usds.approve(address(psm), 100e18);
 
         vm.expectRevert("SafeERC20/transfer-from-failed");
-        psm.deposit(address(dai), user1, 100e18);
+        psm.deposit(address(usds), user1, 100e18);
 
-        dai.mint(user1, 1);
+        usds.mint(user1, 1);
 
-        psm.deposit(address(dai), user1, 100e18);
+        psm.deposit(address(usds), user1, 100e18);
     }
 
     function test_deposit_firstDepositDai() public {
-        dai.mint(user1, 100e18);
+        usds.mint(user1, 100e18);
 
         vm.startPrank(user1);
 
-        dai.approve(address(psm), 100e18);
+        usds.approve(address(psm), 100e18);
 
-        assertEq(dai.allowance(user1, address(psm)), 100e18);
-        assertEq(dai.balanceOf(user1),               100e18);
-        assertEq(dai.balanceOf(address(psm)),        0);
+        assertEq(usds.allowance(user1, address(psm)), 100e18);
+        assertEq(usds.balanceOf(user1),               100e18);
+        assertEq(usds.balanceOf(address(psm)),        0);
 
         assertEq(psm.totalShares(),     0);
         assertEq(psm.shares(user1),     0);
@@ -71,13 +71,13 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(psm.convertToShares(1e18), 1e18);
 
-        uint256 newShares = psm.deposit(address(dai), receiver1, 100e18);
+        uint256 newShares = psm.deposit(address(usds), receiver1, 100e18);
 
         assertEq(newShares, 100e18);
 
-        assertEq(dai.allowance(user1, address(psm)), 0);
-        assertEq(dai.balanceOf(user1),               0);
-        assertEq(dai.balanceOf(address(psm)),        100e18);
+        assertEq(usds.allowance(user1, address(psm)), 0);
+        assertEq(usds.balanceOf(user1),               0);
+        assertEq(usds.balanceOf(address(psm)),        100e18);
 
         assertEq(psm.totalShares(),     100e18);
         assertEq(psm.shares(user1),     0);
@@ -119,15 +119,15 @@ contract PSMDepositTests is PSMTestBase {
     }
 
     function test_deposit_firstDepositSDai() public {
-        sDai.mint(user1, 100e18);
+        susds.mint(user1, 100e18);
 
         vm.startPrank(user1);
 
-        sDai.approve(address(psm), 100e18);
+        susds.approve(address(psm), 100e18);
 
-        assertEq(sDai.allowance(user1, address(psm)), 100e18);
-        assertEq(sDai.balanceOf(user1),               100e18);
-        assertEq(sDai.balanceOf(address(psm)),        0);
+        assertEq(susds.allowance(user1, address(psm)), 100e18);
+        assertEq(susds.balanceOf(user1),               100e18);
+        assertEq(susds.balanceOf(address(psm)),        0);
 
         assertEq(psm.totalShares(),     0);
         assertEq(psm.shares(user1),     0);
@@ -135,13 +135,13 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(psm.convertToShares(1e18), 1e18);
 
-        uint256 newShares = psm.deposit(address(sDai), receiver1, 100e18);
+        uint256 newShares = psm.deposit(address(susds), receiver1, 100e18);
 
         assertEq(newShares, 125e18);
 
-        assertEq(sDai.allowance(user1, address(psm)), 0);
-        assertEq(sDai.balanceOf(user1),               0);
-        assertEq(sDai.balanceOf(address(psm)),        100e18);
+        assertEq(susds.allowance(user1, address(psm)), 0);
+        assertEq(susds.balanceOf(user1),               0);
+        assertEq(susds.balanceOf(address(psm)),        100e18);
 
         assertEq(psm.totalShares(),     125e18);
         assertEq(psm.shares(user1),     0);
@@ -161,14 +161,14 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(newShares, 100e18);
 
-        sDai.mint(user1, 100e18);
-        sDai.approve(address(psm), 100e18);
+        susds.mint(user1, 100e18);
+        susds.approve(address(psm), 100e18);
 
         assertEq(usdc.balanceOf(address(psm)), 100e6);
 
-        assertEq(sDai.allowance(user1, address(psm)), 100e18);
-        assertEq(sDai.balanceOf(user1),               100e18);
-        assertEq(sDai.balanceOf(address(psm)),        0);
+        assertEq(susds.allowance(user1, address(psm)), 100e18);
+        assertEq(susds.balanceOf(user1),               100e18);
+        assertEq(susds.balanceOf(address(psm)),        0);
 
         assertEq(psm.totalShares(),     100e18);
         assertEq(psm.shares(user1),     0);
@@ -176,15 +176,15 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(psm.convertToShares(1e18), 1e18);
 
-        newShares = psm.deposit(address(sDai), receiver1, 100e18);
+        newShares = psm.deposit(address(susds), receiver1, 100e18);
 
         assertEq(newShares, 125e18);
 
         assertEq(usdc.balanceOf(address(psm)), 100e6);
 
-        assertEq(sDai.allowance(user1, address(psm)), 0);
-        assertEq(sDai.balanceOf(user1),               0);
-        assertEq(sDai.balanceOf(address(psm)),        100e18);
+        assertEq(susds.allowance(user1, address(psm)), 0);
+        assertEq(susds.balanceOf(user1),               0);
+        assertEq(susds.balanceOf(address(psm)),        100e18);
 
         assertEq(psm.totalShares(),     225e18);
         assertEq(psm.shares(user1),     0);
@@ -193,10 +193,10 @@ contract PSMDepositTests is PSMTestBase {
         assertEq(psm.convertToShares(1e18), 1e18);
     }
 
-    function testFuzz_deposit_usdcThenSDai(uint256 usdcAmount, uint256 sDaiAmount) public {
+    function testFuzz_deposit_usdcThenSDai(uint256 usdcAmount, uint256 susdsAmount) public {
         // Zero amounts revert
         usdcAmount = _bound(usdcAmount, 1, USDC_TOKEN_MAX);
-        sDaiAmount = _bound(sDaiAmount, 1, SDAI_TOKEN_MAX);
+        susdsAmount = _bound(susdsAmount, 1, SUSDS_TOKEN_MAX);
 
         usdc.mint(user1, usdcAmount);
 
@@ -208,14 +208,14 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(newShares, usdcAmount * 1e12);
 
-        sDai.mint(user1, sDaiAmount);
-        sDai.approve(address(psm), sDaiAmount);
+        susds.mint(user1, susdsAmount);
+        susds.approve(address(psm), susdsAmount);
 
         assertEq(usdc.balanceOf(address(psm)), usdcAmount);
 
-        assertEq(sDai.allowance(user1, address(psm)), sDaiAmount);
-        assertEq(sDai.balanceOf(user1),               sDaiAmount);
-        assertEq(sDai.balanceOf(address(psm)),        0);
+        assertEq(susds.allowance(user1, address(psm)), susdsAmount);
+        assertEq(susds.balanceOf(user1),               susdsAmount);
+        assertEq(susds.balanceOf(address(psm)),        0);
 
         assertEq(psm.totalShares(),     usdcAmount * 1e12);
         assertEq(psm.shares(user1),     0);
@@ -223,19 +223,19 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(psm.convertToShares(1e18), 1e18);
 
-        newShares = psm.deposit(address(sDai), receiver1, sDaiAmount);
+        newShares = psm.deposit(address(susds), receiver1, susdsAmount);
 
-        assertEq(newShares, sDaiAmount * 125/100);
+        assertEq(newShares, susdsAmount * 125/100);
 
         assertEq(usdc.balanceOf(address(psm)), usdcAmount);
 
-        assertEq(sDai.allowance(user1, address(psm)), 0);
-        assertEq(sDai.balanceOf(user1),               0);
-        assertEq(sDai.balanceOf(address(psm)),        sDaiAmount);
+        assertEq(susds.allowance(user1, address(psm)), 0);
+        assertEq(susds.balanceOf(user1),               0);
+        assertEq(susds.balanceOf(address(psm)),        susdsAmount);
 
-        assertEq(psm.totalShares(),     usdcAmount * 1e12 + sDaiAmount * 125/100);
+        assertEq(psm.totalShares(),     usdcAmount * 1e12 + susdsAmount * 125/100);
         assertEq(psm.shares(user1),     0);
-        assertEq(psm.shares(receiver1), usdcAmount * 1e12 + sDaiAmount * 125/100);
+        assertEq(psm.shares(receiver1), usdcAmount * 1e12 + susdsAmount * 125/100);
 
         assertEq(psm.convertToShares(1e18), 1e18);
     }
@@ -251,10 +251,10 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(newShares, 100e18);
 
-        sDai.mint(user1, 100e18);
-        sDai.approve(address(psm), 100e18);
+        susds.mint(user1, 100e18);
+        susds.approve(address(psm), 100e18);
 
-        newShares = psm.deposit(address(sDai), receiver1, 100e18);
+        newShares = psm.deposit(address(susds), receiver1, 100e18);
 
         assertEq(newShares, 125e18);
 
@@ -262,9 +262,9 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(usdc.balanceOf(address(psm)), 100e6);
 
-        assertEq(sDai.allowance(user1, address(psm)), 0);
-        assertEq(sDai.balanceOf(user1),               0);
-        assertEq(sDai.balanceOf(address(psm)),        100e18);
+        assertEq(susds.allowance(user1, address(psm)), 0);
+        assertEq(susds.balanceOf(user1),               0);
+        assertEq(susds.balanceOf(address(psm)),        100e18);
 
         assertEq(psm.totalShares(),     225e18);
         assertEq(psm.shares(user1),     0);
@@ -276,7 +276,7 @@ contract PSMDepositTests is PSMTestBase {
 
         mockRateProvider.__setConversionRate(1.5e27);
 
-        // Total shares / (100 USDC + 150 sDAI value)
+        // Total shares / (100 USDC + 150 sUSDS value)
         uint256 expectedConversionRate = 225 * 1e18 / 250;
 
         assertEq(expectedConversionRate, 0.9e18);
@@ -285,25 +285,25 @@ contract PSMDepositTests is PSMTestBase {
 
         vm.startPrank(user2);
 
-        sDai.mint(user2, 100e18);
-        sDai.approve(address(psm), 100e18);
+        susds.mint(user2, 100e18);
+        susds.approve(address(psm), 100e18);
 
-        assertEq(sDai.allowance(user2, address(psm)), 100e18);
-        assertEq(sDai.balanceOf(user2),               100e18);
-        assertEq(sDai.balanceOf(address(psm)),        100e18);
+        assertEq(susds.allowance(user2, address(psm)), 100e18);
+        assertEq(susds.balanceOf(user2),               100e18);
+        assertEq(susds.balanceOf(address(psm)),        100e18);
 
         assertEq(psm.convertToAssetValue(psm.shares(receiver1)), 250e18);
         assertEq(psm.convertToAssetValue(psm.shares(receiver2)), 0);
 
         assertEq(psm.totalAssets(), 250e18);
 
-        newShares = psm.deposit(address(sDai), receiver2, 100e18);
+        newShares = psm.deposit(address(susds), receiver2, 100e18);
 
         assertEq(newShares, 135e18);
 
-        assertEq(sDai.allowance(user2, address(psm)), 0);
-        assertEq(sDai.balanceOf(user2),               0);
-        assertEq(sDai.balanceOf(address(psm)),        200e18);
+        assertEq(susds.allowance(user2, address(psm)), 0);
+        assertEq(susds.balanceOf(user2),               0);
+        assertEq(susds.balanceOf(address(psm)),        200e18);
 
         // Depositing 150 dollars of value at 0.9 exchange rate
         uint256 expectedShares = 150e18 * 9/10;
@@ -325,19 +325,19 @@ contract PSMDepositTests is PSMTestBase {
 
     function testFuzz_deposit_multiUser_changeConversionRate(
         uint256 usdcAmount,
-        uint256 sDaiAmount1,
-        uint256 sDaiAmount2,
+        uint256 susdsAmount1,
+        uint256 susdsAmount2,
         uint256 newRate
     )
         public
     {
         // Zero amounts revert
-        usdcAmount  = _bound(usdcAmount,  1,       USDC_TOKEN_MAX);
-        sDaiAmount1 = _bound(sDaiAmount1, 1,       SDAI_TOKEN_MAX);
-        sDaiAmount2 = _bound(sDaiAmount2, 1,       SDAI_TOKEN_MAX);
-        newRate     = _bound(newRate,     1.25e27, 1000e27);
+        usdcAmount   = _bound(usdcAmount,   1,       USDC_TOKEN_MAX);
+        susdsAmount1 = _bound(susdsAmount1, 1,       SUSDS_TOKEN_MAX);
+        susdsAmount2 = _bound(susdsAmount2, 1,       SUSDS_TOKEN_MAX);
+        newRate      = _bound(newRate,      1.25e27, 1000e27);
 
-        uint256 user1DepositValue = usdcAmount * 1e12 + sDaiAmount1 * 125/100;
+        uint256 user1DepositValue = usdcAmount * 1e12 + susdsAmount1 * 125/100;
 
         usdc.mint(user1, usdcAmount);
 
@@ -349,19 +349,19 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(newShares, usdcAmount * 1e12);
 
-        sDai.mint(user1, sDaiAmount1);
-        sDai.approve(address(psm), sDaiAmount1);
+        susds.mint(user1, susdsAmount1);
+        susds.approve(address(psm), susdsAmount1);
 
-        newShares = psm.deposit(address(sDai), receiver1, sDaiAmount1);
+        newShares = psm.deposit(address(susds), receiver1, susdsAmount1);
 
-        assertEq(newShares, sDaiAmount1 * 125/100);
+        assertEq(newShares, susdsAmount1 * 125/100);
 
         vm.stopPrank();
 
         assertEq(usdc.balanceOf(address(psm)), usdcAmount);
 
-        assertEq(sDai.balanceOf(user1),        0);
-        assertEq(sDai.balanceOf(address(psm)), sDaiAmount1);
+        assertEq(susds.balanceOf(user1),        0);
+        assertEq(susds.balanceOf(address(psm)), susdsAmount1);
 
         // Deposited at 1:1 conversion
         uint256 receiver1Shares = user1DepositValue;
@@ -374,15 +374,15 @@ contract PSMDepositTests is PSMTestBase {
 
         vm.startPrank(user2);
 
-        sDai.mint(user2, sDaiAmount2);
-        sDai.approve(address(psm), sDaiAmount2);
+        susds.mint(user2, susdsAmount2);
+        susds.approve(address(psm), susdsAmount2);
 
-        assertEq(sDai.allowance(user2, address(psm)), sDaiAmount2);
-        assertEq(sDai.balanceOf(user2),               sDaiAmount2);
-        assertEq(sDai.balanceOf(address(psm)),        sDaiAmount1);
+        assertEq(susds.allowance(user2, address(psm)), susdsAmount2);
+        assertEq(susds.balanceOf(user2),               susdsAmount2);
+        assertEq(susds.balanceOf(address(psm)),        susdsAmount1);
 
         // Receiver1 has gained from conversion change
-        uint256 receiver1NewValue = user1DepositValue + sDaiAmount1 * (newRate - 1.25e27) / 1e27;
+        uint256 receiver1NewValue = user1DepositValue + susdsAmount1 * (newRate - 1.25e27) / 1e27;
 
         // Receiver1 has gained from conversion change
         assertApproxEqAbs(
@@ -395,18 +395,18 @@ contract PSMDepositTests is PSMTestBase {
 
         assertApproxEqAbs(psm.totalAssets(), receiver1NewValue, 1);
 
-        newShares = psm.deposit(address(sDai), receiver2, sDaiAmount2);
+        newShares = psm.deposit(address(susds), receiver2, susdsAmount2);
 
         // Using queried values here instead of derived to avoid larger errors getting introduced
         // Assertions above prove that these values are as expected.
         uint256 receiver2Shares
-            = (sDaiAmount2 * newRate / 1e27) * psm.totalShares() / psm.totalAssets();
+            = (susdsAmount2 * newRate / 1e27) * psm.totalShares() / psm.totalAssets();
 
         assertApproxEqAbs(newShares, receiver2Shares, 2);
 
-        assertEq(sDai.allowance(user2, address(psm)), 0);
-        assertEq(sDai.balanceOf(user2),               0);
-        assertEq(sDai.balanceOf(address(psm)),        sDaiAmount1 + sDaiAmount2);
+        assertEq(susds.allowance(user2, address(psm)), 0);
+        assertEq(susds.balanceOf(user2),               0);
+        assertEq(susds.balanceOf(address(psm)),        susdsAmount1 + susdsAmount2);
 
         assertEq(psm.shares(user1), 0);
         assertEq(psm.shares(user2), 0);
@@ -415,7 +415,7 @@ contract PSMDepositTests is PSMTestBase {
         assertApproxEqAbs(psm.shares(receiver1), receiver1Shares,                   2);
         assertApproxEqAbs(psm.shares(receiver2), receiver2Shares,                   2);
 
-        uint256 receiver2NewValue = sDaiAmount2 * newRate / 1e27;
+        uint256 receiver2NewValue = susdsAmount2 * newRate / 1e27;
 
         // Rate change of up to 1000x introduces errors
         assertApproxEqAbs(psm.convertToAssetValue(psm.shares(receiver1)), receiver1NewValue, 1000);

--- a/test/unit/Deposit.t.sol
+++ b/test/unit/Deposit.t.sol
@@ -19,7 +19,7 @@ contract PSMDepositTests is PSMTestBase {
         psm.deposit(address(usdc), user1, 0);
     }
 
-    function test_deposit_notAsset0OrAsset1() public {
+    function test_deposit_notUsdcOrUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.deposit(makeAddr("new-asset"), user1, 100e6);
     }

--- a/test/unit/Deposit.t.sol
+++ b/test/unit/Deposit.t.sol
@@ -54,7 +54,7 @@ contract PSMDepositTests is PSMTestBase {
         psm.deposit(address(usds), user1, 100e18);
     }
 
-    function test_deposit_firstDepositDai() public {
+    function test_deposit_firstDepositUsds() public {
         usds.mint(user1, 100e18);
 
         vm.startPrank(user1);
@@ -118,7 +118,7 @@ contract PSMDepositTests is PSMTestBase {
         assertEq(psm.convertToShares(1e18), 1e18);
     }
 
-    function test_deposit_firstDepositSDai() public {
+    function test_deposit_firstDepositSUsds() public {
         susds.mint(user1, 100e18);
 
         vm.startPrank(user1);
@@ -150,7 +150,7 @@ contract PSMDepositTests is PSMTestBase {
         assertEq(psm.convertToShares(1e18), 1e18);
     }
 
-    function test_deposit_usdcThenSDai() public {
+    function test_deposit_usdcThenSUsds() public {
         usdc.mint(user1, 100e6);
 
         vm.startPrank(user1);
@@ -193,7 +193,7 @@ contract PSMDepositTests is PSMTestBase {
         assertEq(psm.convertToShares(1e18), 1e18);
     }
 
-    function testFuzz_deposit_usdcThenSDai(uint256 usdcAmount, uint256 susdsAmount) public {
+    function testFuzz_deposit_usdcThenSUsds(uint256 usdcAmount, uint256 susdsAmount) public {
         // Zero amounts revert
         usdcAmount = _bound(usdcAmount, 1, USDC_TOKEN_MAX);
         susdsAmount = _bound(susdsAmount, 1, SUSDS_TOKEN_MAX);

--- a/test/unit/Events.t.sol
+++ b/test/unit/Events.t.sol
@@ -39,12 +39,12 @@ contract PSMEventTests is PSMTestBase {
     function test_deposit_events() public {
         vm.startPrank(sender);
 
-        dai.mint(sender, 100e18);
-        dai.approve(address(psm), 100e18);
+        usds.mint(sender, 100e18);
+        usds.approve(address(psm), 100e18);
 
         vm.expectEmit(address(psm));
-        emit Deposit(address(dai), sender, receiver, 100e18, 100e18);
-        psm.deposit(address(dai), receiver, 100e18);
+        emit Deposit(address(usds), sender, receiver, 100e18, 100e18);
+        psm.deposit(address(usds), receiver, 100e18);
 
         usdc.mint(sender, 100e6);
         usdc.approve(address(psm), 100e6);
@@ -53,49 +53,49 @@ contract PSMEventTests is PSMTestBase {
         emit Deposit(address(usdc), sender, receiver, 100e6, 100e18);
         psm.deposit(address(usdc), receiver, 100e6);
 
-        sDai.mint(sender, 100e18);
-        sDai.approve(address(psm), 100e18);
+        susds.mint(sender, 100e18);
+        susds.approve(address(psm), 100e18);
 
         vm.expectEmit(address(psm));
-        emit Deposit(address(sDai), sender, receiver, 100e18, 125e18);
-        psm.deposit(address(sDai), receiver, 100e18);
+        emit Deposit(address(susds), sender, receiver, 100e18, 125e18);
+        psm.deposit(address(susds), receiver, 100e18);
     }
 
     function test_withdraw_events() public {
-        _deposit(address(dai),  sender, 100e18);
+        _deposit(address(usds),  sender, 100e18);
         _deposit(address(usdc), sender, 100e6);
-        _deposit(address(sDai), sender, 100e18);
+        _deposit(address(susds), sender, 100e18);
 
         vm.startPrank(sender);
 
         vm.expectEmit(address(psm));
-        emit Withdraw(address(dai), sender, receiver, 100e18, 100e18);
-        psm.withdraw(address(dai), receiver, 100e18);
+        emit Withdraw(address(usds), sender, receiver, 100e18, 100e18);
+        psm.withdraw(address(usds), receiver, 100e18);
 
         vm.expectEmit(address(psm));
         emit Withdraw(address(usdc), sender, receiver, 100e6, 100e18);
         psm.withdraw(address(usdc), receiver, 100e6);
 
         vm.expectEmit(address(psm));
-        emit Withdraw(address(sDai), sender, receiver, 100e18, 125e18);
-        psm.withdraw(address(sDai), receiver, 100e18);
+        emit Withdraw(address(susds), sender, receiver, 100e18, 125e18);
+        psm.withdraw(address(susds), receiver, 100e18);
     }
 
     function test_swap_events() public {
-        dai.mint(address(psm),  1000e18);
+        usds.mint(address(psm),  1000e18);
         usdc.mint(address(psm), 1000e6);
-        sDai.mint(address(psm), 1000e18);
+        susds.mint(address(psm), 1000e18);
 
         vm.startPrank(sender);
 
-        _swapEventTest(address(dai), address(usdc), 100e18, 100e6, 1);
-        _swapEventTest(address(dai), address(sDai), 100e18, 80e18, 2);
+        _swapEventTest(address(usds), address(usdc),  100e18, 100e6, 1);
+        _swapEventTest(address(usds), address(susds), 100e18, 80e18, 2);
 
-        _swapEventTest(address(usdc), address(dai),  100e6, 100e18, 3);
-        _swapEventTest(address(usdc), address(sDai), 100e6, 80e18,  4);
+        _swapEventTest(address(usdc), address(usds),  100e6, 100e18, 3);
+        _swapEventTest(address(usdc), address(susds), 100e6, 80e18,  4);
 
-        _swapEventTest(address(sDai), address(dai),  100e18, 125e18, 5);
-        _swapEventTest(address(sDai), address(usdc), 100e18, 125e6,  6);
+        _swapEventTest(address(susds), address(usds), 100e18, 125e18, 5);
+        _swapEventTest(address(susds), address(usdc), 100e18, 125e6,  6);
     }
 
     function _swapEventTest(

--- a/test/unit/Getters.t.sol
+++ b/test/unit/Getters.t.sol
@@ -22,189 +22,189 @@ contract PSMHarnessTests is PSMTestBase {
         );
     }
 
-    function test_getAsset1Value() public view {
-        assertEq(psmHarness.getAsset1Value(1), 1);
-        assertEq(psmHarness.getAsset1Value(2), 2);
-        assertEq(psmHarness.getAsset1Value(3), 3);
+    function test_getUsdsValue() public view {
+        assertEq(psmHarness.getUsdsValue(1), 1);
+        assertEq(psmHarness.getUsdsValue(2), 2);
+        assertEq(psmHarness.getUsdsValue(3), 3);
 
-        assertEq(psmHarness.getAsset1Value(100e18), 100e18);
-        assertEq(psmHarness.getAsset1Value(200e18), 200e18);
-        assertEq(psmHarness.getAsset1Value(300e18), 300e18);
+        assertEq(psmHarness.getUsdsValue(100e18), 100e18);
+        assertEq(psmHarness.getUsdsValue(200e18), 200e18);
+        assertEq(psmHarness.getUsdsValue(300e18), 300e18);
 
-        assertEq(psmHarness.getAsset1Value(100_000_000_000e18), 100_000_000_000e18);
-        assertEq(psmHarness.getAsset1Value(200_000_000_000e18), 200_000_000_000e18);
-        assertEq(psmHarness.getAsset1Value(300_000_000_000e18), 300_000_000_000e18);
+        assertEq(psmHarness.getUsdsValue(100_000_000_000e18), 100_000_000_000e18);
+        assertEq(psmHarness.getUsdsValue(200_000_000_000e18), 200_000_000_000e18);
+        assertEq(psmHarness.getUsdsValue(300_000_000_000e18), 300_000_000_000e18);
     }
 
-    function testFuzz_getAsset1Value(uint256 amount) public view {
+    function testFuzz_getUsdsValue(uint256 amount) public view {
         amount = _bound(amount, 0, 1e45);
 
-        assertEq(psmHarness.getAsset1Value(amount), amount);
+        assertEq(psmHarness.getUsdsValue(amount), amount);
     }
 
-    function test_getAsset0Value() public view {
-        assertEq(psmHarness.getAsset0Value(1), 1e12);
-        assertEq(psmHarness.getAsset0Value(2), 2e12);
-        assertEq(psmHarness.getAsset0Value(3), 3e12);
+    function test_getUsdcValue() public view {
+        assertEq(psmHarness.getUsdcValue(1), 1e12);
+        assertEq(psmHarness.getUsdcValue(2), 2e12);
+        assertEq(psmHarness.getUsdcValue(3), 3e12);
 
-        assertEq(psmHarness.getAsset0Value(100e6), 100e18);
-        assertEq(psmHarness.getAsset0Value(200e6), 200e18);
-        assertEq(psmHarness.getAsset0Value(300e6), 300e18);
+        assertEq(psmHarness.getUsdcValue(100e6), 100e18);
+        assertEq(psmHarness.getUsdcValue(200e6), 200e18);
+        assertEq(psmHarness.getUsdcValue(300e6), 300e18);
 
-        assertEq(psmHarness.getAsset0Value(100_000_000_000e6), 100_000_000_000e18);
-        assertEq(psmHarness.getAsset0Value(200_000_000_000e6), 200_000_000_000e18);
-        assertEq(psmHarness.getAsset0Value(300_000_000_000e6), 300_000_000_000e18);
+        assertEq(psmHarness.getUsdcValue(100_000_000_000e6), 100_000_000_000e18);
+        assertEq(psmHarness.getUsdcValue(200_000_000_000e6), 200_000_000_000e18);
+        assertEq(psmHarness.getUsdcValue(300_000_000_000e6), 300_000_000_000e18);
     }
 
-    function testFuzz_getAsset0Value(uint256 amount) public view {
+    function testFuzz_getUsdcValue(uint256 amount) public view {
         amount = _bound(amount, 0, 1e45);
 
-        assertEq(psmHarness.getAsset0Value(amount), amount * 1e12);
+        assertEq(psmHarness.getUsdcValue(amount), amount * 1e12);
     }
 
-    function test_getAsset2Value() public {
-        assertEq(psmHarness.getAsset2Value(1, false), 1);
-        assertEq(psmHarness.getAsset2Value(2, false), 2);
-        assertEq(psmHarness.getAsset2Value(3, false), 3);
-        assertEq(psmHarness.getAsset2Value(4, false), 5);
+    function test_getSUsdsValue() public {
+        assertEq(psmHarness.getSUsdsValue(1, false), 1);
+        assertEq(psmHarness.getSUsdsValue(2, false), 2);
+        assertEq(psmHarness.getSUsdsValue(3, false), 3);
+        assertEq(psmHarness.getSUsdsValue(4, false), 5);
 
         // Rounding up
-        assertEq(psmHarness.getAsset2Value(1, true), 2);
-        assertEq(psmHarness.getAsset2Value(2, true), 3);
-        assertEq(psmHarness.getAsset2Value(3, true), 4);
-        assertEq(psmHarness.getAsset2Value(4, true), 5);
+        assertEq(psmHarness.getSUsdsValue(1, true), 2);
+        assertEq(psmHarness.getSUsdsValue(2, true), 3);
+        assertEq(psmHarness.getSUsdsValue(3, true), 4);
+        assertEq(psmHarness.getSUsdsValue(4, true), 5);
 
-        assertEq(psmHarness.getAsset2Value(1e18, false), 1.25e18);
-        assertEq(psmHarness.getAsset2Value(2e18, false), 2.5e18);
-        assertEq(psmHarness.getAsset2Value(3e18, false), 3.75e18);
-        assertEq(psmHarness.getAsset2Value(4e18, false), 5e18);
+        assertEq(psmHarness.getSUsdsValue(1e18, false), 1.25e18);
+        assertEq(psmHarness.getSUsdsValue(2e18, false), 2.5e18);
+        assertEq(psmHarness.getSUsdsValue(3e18, false), 3.75e18);
+        assertEq(psmHarness.getSUsdsValue(4e18, false), 5e18);
 
         // No rounding but shows why rounding occurred at lower values
-        assertEq(psmHarness.getAsset2Value(1e18, true), 1.25e18);
-        assertEq(psmHarness.getAsset2Value(2e18, true), 2.5e18);
-        assertEq(psmHarness.getAsset2Value(3e18, true), 3.75e18);
-        assertEq(psmHarness.getAsset2Value(4e18, true), 5e18);
+        assertEq(psmHarness.getSUsdsValue(1e18, true), 1.25e18);
+        assertEq(psmHarness.getSUsdsValue(2e18, true), 2.5e18);
+        assertEq(psmHarness.getSUsdsValue(3e18, true), 3.75e18);
+        assertEq(psmHarness.getSUsdsValue(4e18, true), 5e18);
 
         mockRateProvider.__setConversionRate(1.6e27);
 
-        assertEq(psmHarness.getAsset2Value(1, false), 1);
-        assertEq(psmHarness.getAsset2Value(2, false), 3);
-        assertEq(psmHarness.getAsset2Value(3, false), 4);
-        assertEq(psmHarness.getAsset2Value(4, false), 6);
+        assertEq(psmHarness.getSUsdsValue(1, false), 1);
+        assertEq(psmHarness.getSUsdsValue(2, false), 3);
+        assertEq(psmHarness.getSUsdsValue(3, false), 4);
+        assertEq(psmHarness.getSUsdsValue(4, false), 6);
 
         // Rounding up
-        assertEq(psmHarness.getAsset2Value(1, true), 2);
-        assertEq(psmHarness.getAsset2Value(2, true), 4);
-        assertEq(psmHarness.getAsset2Value(3, true), 5);
-        assertEq(psmHarness.getAsset2Value(4, true), 7);
+        assertEq(psmHarness.getSUsdsValue(1, true), 2);
+        assertEq(psmHarness.getSUsdsValue(2, true), 4);
+        assertEq(psmHarness.getSUsdsValue(3, true), 5);
+        assertEq(psmHarness.getSUsdsValue(4, true), 7);
 
-        assertEq(psmHarness.getAsset2Value(1e18, false), 1.6e18);
-        assertEq(psmHarness.getAsset2Value(2e18, false), 3.2e18);
-        assertEq(psmHarness.getAsset2Value(3e18, false), 4.8e18);
-        assertEq(psmHarness.getAsset2Value(4e18, false), 6.4e18);
+        assertEq(psmHarness.getSUsdsValue(1e18, false), 1.6e18);
+        assertEq(psmHarness.getSUsdsValue(2e18, false), 3.2e18);
+        assertEq(psmHarness.getSUsdsValue(3e18, false), 4.8e18);
+        assertEq(psmHarness.getSUsdsValue(4e18, false), 6.4e18);
 
         // No rounding but shows why rounding occurred at lower values
-        assertEq(psmHarness.getAsset2Value(1e18, true), 1.6e18);
-        assertEq(psmHarness.getAsset2Value(2e18, true), 3.2e18);
-        assertEq(psmHarness.getAsset2Value(3e18, true), 4.8e18);
-        assertEq(psmHarness.getAsset2Value(4e18, true), 6.4e18);
+        assertEq(psmHarness.getSUsdsValue(1e18, true), 1.6e18);
+        assertEq(psmHarness.getSUsdsValue(2e18, true), 3.2e18);
+        assertEq(psmHarness.getSUsdsValue(3e18, true), 4.8e18);
+        assertEq(psmHarness.getSUsdsValue(4e18, true), 6.4e18);
 
         mockRateProvider.__setConversionRate(0.8e27);
 
-        assertEq(psmHarness.getAsset2Value(1, false), 0);
-        assertEq(psmHarness.getAsset2Value(2, false), 1);
-        assertEq(psmHarness.getAsset2Value(3, false), 2);
-        assertEq(psmHarness.getAsset2Value(4, false), 3);
+        assertEq(psmHarness.getSUsdsValue(1, false), 0);
+        assertEq(psmHarness.getSUsdsValue(2, false), 1);
+        assertEq(psmHarness.getSUsdsValue(3, false), 2);
+        assertEq(psmHarness.getSUsdsValue(4, false), 3);
 
         // Rounding up
-        assertEq(psmHarness.getAsset2Value(1, true), 1);
-        assertEq(psmHarness.getAsset2Value(2, true), 2);
-        assertEq(psmHarness.getAsset2Value(3, true), 3);
-        assertEq(psmHarness.getAsset2Value(4, true), 4);
+        assertEq(psmHarness.getSUsdsValue(1, true), 1);
+        assertEq(psmHarness.getSUsdsValue(2, true), 2);
+        assertEq(psmHarness.getSUsdsValue(3, true), 3);
+        assertEq(psmHarness.getSUsdsValue(4, true), 4);
 
-        assertEq(psmHarness.getAsset2Value(1e18, false), 0.8e18);
-        assertEq(psmHarness.getAsset2Value(2e18, false), 1.6e18);
-        assertEq(psmHarness.getAsset2Value(3e18, false), 2.4e18);
-        assertEq(psmHarness.getAsset2Value(4e18, false), 3.2e18);
+        assertEq(psmHarness.getSUsdsValue(1e18, false), 0.8e18);
+        assertEq(psmHarness.getSUsdsValue(2e18, false), 1.6e18);
+        assertEq(psmHarness.getSUsdsValue(3e18, false), 2.4e18);
+        assertEq(psmHarness.getSUsdsValue(4e18, false), 3.2e18);
 
         // No rounding but shows why rounding occurred at lower values
-        assertEq(psmHarness.getAsset2Value(1e18, true), 0.8e18);
-        assertEq(psmHarness.getAsset2Value(2e18, true), 1.6e18);
-        assertEq(psmHarness.getAsset2Value(3e18, true), 2.4e18);
-        assertEq(psmHarness.getAsset2Value(4e18, true), 3.2e18);
+        assertEq(psmHarness.getSUsdsValue(1e18, true), 0.8e18);
+        assertEq(psmHarness.getSUsdsValue(2e18, true), 1.6e18);
+        assertEq(psmHarness.getSUsdsValue(3e18, true), 2.4e18);
+        assertEq(psmHarness.getSUsdsValue(4e18, true), 3.2e18);
     }
 
-    function testFuzz_getAsset2Value_roundDown(uint256 conversionRate, uint256 amount) public {
+    function testFuzz_getSUsdsValue_roundDown(uint256 conversionRate, uint256 amount) public {
         conversionRate = _bound(conversionRate, 0, 1000e27);
         amount         = _bound(amount,         0, SDAI_TOKEN_MAX);
 
         mockRateProvider.__setConversionRate(conversionRate);
 
-        assertEq(psmHarness.getAsset2Value(amount, false), amount * conversionRate / 1e27);
+        assertEq(psmHarness.getSUsdsValue(amount, false), amount * conversionRate / 1e27);
     }
 
     function test_getAssetValue() public view {
-        assertEq(psmHarness.getAssetValue(address(usdc), 1, false), psmHarness.getAsset0Value(1));
-        assertEq(psmHarness.getAssetValue(address(usdc), 2, false), psmHarness.getAsset0Value(2));
-        assertEq(psmHarness.getAssetValue(address(usdc), 3, false), psmHarness.getAsset0Value(3));
+        assertEq(psmHarness.getAssetValue(address(usdc), 1, false), psmHarness.getUsdcValue(1));
+        assertEq(psmHarness.getAssetValue(address(usdc), 2, false), psmHarness.getUsdcValue(2));
+        assertEq(psmHarness.getAssetValue(address(usdc), 3, false), psmHarness.getUsdcValue(3));
 
-        assertEq(psmHarness.getAssetValue(address(usdc), 1, true), psmHarness.getAsset0Value(1));
-        assertEq(psmHarness.getAssetValue(address(usdc), 2, true), psmHarness.getAsset0Value(2));
-        assertEq(psmHarness.getAssetValue(address(usdc), 3, true), psmHarness.getAsset0Value(3));
+        assertEq(psmHarness.getAssetValue(address(usdc), 1, true), psmHarness.getUsdcValue(1));
+        assertEq(psmHarness.getAssetValue(address(usdc), 2, true), psmHarness.getUsdcValue(2));
+        assertEq(psmHarness.getAssetValue(address(usdc), 3, true), psmHarness.getUsdcValue(3));
 
-        assertEq(psmHarness.getAssetValue(address(usdc), 1e6, false), psmHarness.getAsset0Value(1e6));
-        assertEq(psmHarness.getAssetValue(address(usdc), 2e6, false), psmHarness.getAsset0Value(2e6));
-        assertEq(psmHarness.getAssetValue(address(usdc), 3e6, false), psmHarness.getAsset0Value(3e6));
+        assertEq(psmHarness.getAssetValue(address(usdc), 1e6, false), psmHarness.getUsdcValue(1e6));
+        assertEq(psmHarness.getAssetValue(address(usdc), 2e6, false), psmHarness.getUsdcValue(2e6));
+        assertEq(psmHarness.getAssetValue(address(usdc), 3e6, false), psmHarness.getUsdcValue(3e6));
 
-        assertEq(psmHarness.getAssetValue(address(usdc), 1e6, true), psmHarness.getAsset0Value(1e6));
-        assertEq(psmHarness.getAssetValue(address(usdc), 2e6, true), psmHarness.getAsset0Value(2e6));
-        assertEq(psmHarness.getAssetValue(address(usdc), 3e6, true), psmHarness.getAsset0Value(3e6));
+        assertEq(psmHarness.getAssetValue(address(usdc), 1e6, true), psmHarness.getUsdcValue(1e6));
+        assertEq(psmHarness.getAssetValue(address(usdc), 2e6, true), psmHarness.getUsdcValue(2e6));
+        assertEq(psmHarness.getAssetValue(address(usdc), 3e6, true), psmHarness.getUsdcValue(3e6));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1, false), psmHarness.getAsset1Value(1));
-        assertEq(psmHarness.getAssetValue(address(dai), 2, false), psmHarness.getAsset1Value(2));
-        assertEq(psmHarness.getAssetValue(address(dai), 3, false), psmHarness.getAsset1Value(3));
+        assertEq(psmHarness.getAssetValue(address(dai), 1, false), psmHarness.getUsdsValue(1));
+        assertEq(psmHarness.getAssetValue(address(dai), 2, false), psmHarness.getUsdsValue(2));
+        assertEq(psmHarness.getAssetValue(address(dai), 3, false), psmHarness.getUsdsValue(3));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1, true), psmHarness.getAsset1Value(1));
-        assertEq(psmHarness.getAssetValue(address(dai), 2, true), psmHarness.getAsset1Value(2));
-        assertEq(psmHarness.getAssetValue(address(dai), 3, true), psmHarness.getAsset1Value(3));
+        assertEq(psmHarness.getAssetValue(address(dai), 1, true), psmHarness.getUsdsValue(1));
+        assertEq(psmHarness.getAssetValue(address(dai), 2, true), psmHarness.getUsdsValue(2));
+        assertEq(psmHarness.getAssetValue(address(dai), 3, true), psmHarness.getUsdsValue(3));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1e18, false), psmHarness.getAsset1Value(1e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 2e18, false), psmHarness.getAsset1Value(2e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 3e18, false), psmHarness.getAsset1Value(3e18));
+        assertEq(psmHarness.getAssetValue(address(dai), 1e18, false), psmHarness.getUsdsValue(1e18));
+        assertEq(psmHarness.getAssetValue(address(dai), 2e18, false), psmHarness.getUsdsValue(2e18));
+        assertEq(psmHarness.getAssetValue(address(dai), 3e18, false), psmHarness.getUsdsValue(3e18));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1e18, true), psmHarness.getAsset1Value(1e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 2e18, true), psmHarness.getAsset1Value(2e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 3e18, true), psmHarness.getAsset1Value(3e18));
+        assertEq(psmHarness.getAssetValue(address(dai), 1e18, true), psmHarness.getUsdsValue(1e18));
+        assertEq(psmHarness.getAssetValue(address(dai), 2e18, true), psmHarness.getUsdsValue(2e18));
+        assertEq(psmHarness.getAssetValue(address(dai), 3e18, true), psmHarness.getUsdsValue(3e18));
 
-        assertEq(psmHarness.getAssetValue(address(sDai), 1, false), psmHarness.getAsset2Value(1, false));
-        assertEq(psmHarness.getAssetValue(address(sDai), 2, false), psmHarness.getAsset2Value(2, false));
-        assertEq(psmHarness.getAssetValue(address(sDai), 3, false), psmHarness.getAsset2Value(3, false));
+        assertEq(psmHarness.getAssetValue(address(sDai), 1, false), psmHarness.getSUsdsValue(1, false));
+        assertEq(psmHarness.getAssetValue(address(sDai), 2, false), psmHarness.getSUsdsValue(2, false));
+        assertEq(psmHarness.getAssetValue(address(sDai), 3, false), psmHarness.getSUsdsValue(3, false));
 
-        assertEq(psmHarness.getAssetValue(address(sDai), 1e18, false), psmHarness.getAsset2Value(1e18, false));
-        assertEq(psmHarness.getAssetValue(address(sDai), 2e18, false), psmHarness.getAsset2Value(2e18, false));
-        assertEq(psmHarness.getAssetValue(address(sDai), 3e18, false), psmHarness.getAsset2Value(3e18, false));
+        assertEq(psmHarness.getAssetValue(address(sDai), 1e18, false), psmHarness.getSUsdsValue(1e18, false));
+        assertEq(psmHarness.getAssetValue(address(sDai), 2e18, false), psmHarness.getSUsdsValue(2e18, false));
+        assertEq(psmHarness.getAssetValue(address(sDai), 3e18, false), psmHarness.getSUsdsValue(3e18, false));
 
-        assertEq(psmHarness.getAssetValue(address(sDai), 1, true), psmHarness.getAsset2Value(1, true));
-        assertEq(psmHarness.getAssetValue(address(sDai), 2, true), psmHarness.getAsset2Value(2, true));
-        assertEq(psmHarness.getAssetValue(address(sDai), 3, true), psmHarness.getAsset2Value(3, true));
+        assertEq(psmHarness.getAssetValue(address(sDai), 1, true), psmHarness.getSUsdsValue(1, true));
+        assertEq(psmHarness.getAssetValue(address(sDai), 2, true), psmHarness.getSUsdsValue(2, true));
+        assertEq(psmHarness.getAssetValue(address(sDai), 3, true), psmHarness.getSUsdsValue(3, true));
 
-        assertEq(psmHarness.getAssetValue(address(sDai), 1e18, true), psmHarness.getAsset2Value(1e18, true));
-        assertEq(psmHarness.getAssetValue(address(sDai), 2e18, true), psmHarness.getAsset2Value(2e18, true));
-        assertEq(psmHarness.getAssetValue(address(sDai), 3e18, true), psmHarness.getAsset2Value(3e18, true));
+        assertEq(psmHarness.getAssetValue(address(sDai), 1e18, true), psmHarness.getSUsdsValue(1e18, true));
+        assertEq(psmHarness.getAssetValue(address(sDai), 2e18, true), psmHarness.getSUsdsValue(2e18, true));
+        assertEq(psmHarness.getAssetValue(address(sDai), 3e18, true), psmHarness.getSUsdsValue(3e18, true));
     }
 
     function testFuzz_getAssetValue(uint256 amount) public view {
         amount = _bound(amount, 0, SDAI_TOKEN_MAX);
 
-        // `asset0` and `asset1` return the same values whether `roundUp` is true or false
-        assertEq(psmHarness.getAssetValue(address(usdc), amount, true),  psmHarness.getAsset0Value(amount));
-        assertEq(psmHarness.getAssetValue(address(usdc), amount, true),  psmHarness.getAsset0Value(amount));
-        assertEq(psmHarness.getAssetValue(address(dai),  amount, false), psmHarness.getAsset1Value(amount));
-        assertEq(psmHarness.getAssetValue(address(dai),  amount, false), psmHarness.getAsset1Value(amount));
+        // `usdc` and `usds` return the same values whether `roundUp` is true or false
+        assertEq(psmHarness.getAssetValue(address(usdc), amount, true),  psmHarness.getUsdcValue(amount));
+        assertEq(psmHarness.getAssetValue(address(usdc), amount, true),  psmHarness.getUsdcValue(amount));
+        assertEq(psmHarness.getAssetValue(address(dai),  amount, false), psmHarness.getUsdsValue(amount));
+        assertEq(psmHarness.getAssetValue(address(dai),  amount, false), psmHarness.getUsdsValue(amount));
 
-        // `asset2` returns different values depending on the value of `roundUp`, but always same as underlying function
-        assertEq(psmHarness.getAssetValue(address(sDai), amount, false), psmHarness.getAsset2Value(amount, false));
-        assertEq(psmHarness.getAssetValue(address(sDai), amount, true),  psmHarness.getAsset2Value(amount, true));
+        // `susds` returns different values depending on the value of `roundUp`, but always same as underlying function
+        assertEq(psmHarness.getAssetValue(address(sDai), amount, false), psmHarness.getSUsdsValue(amount, false));
+        assertEq(psmHarness.getAssetValue(address(sDai), amount, true),  psmHarness.getSUsdsValue(amount, true));
     }
 
     function test_getAssetValue_zeroAddress() public {

--- a/test/unit/Getters.t.sol
+++ b/test/unit/Getters.t.sol
@@ -14,6 +14,7 @@ contract PSMHarnessTests is PSMTestBase {
     function setUp() public override {
         super.setUp();
         psmHarness = new PSM3Harness(
+            address(admin),
             address(dai),
             address(usdc),
             address(sDai),

--- a/test/unit/Getters.t.sol
+++ b/test/unit/Getters.t.sol
@@ -16,8 +16,8 @@ contract PSMHarnessTests is PSMTestBase {
         psmHarness = new PSM3Harness(
             address(owner),
             address(usdc),
-            address(dai),
-            address(sDai),
+            address(usds),
+            address(susds),
             address(rateProvider)
         );
     }
@@ -136,7 +136,7 @@ contract PSMHarnessTests is PSMTestBase {
 
     function testFuzz_getSUsdsValue_roundDown(uint256 conversionRate, uint256 amount) public {
         conversionRate = _bound(conversionRate, 0, 1000e27);
-        amount         = _bound(amount,         0, SDAI_TOKEN_MAX);
+        amount         = _bound(amount,         0, SUSDS_TOKEN_MAX);
 
         mockRateProvider.__setConversionRate(conversionRate);
 
@@ -160,51 +160,51 @@ contract PSMHarnessTests is PSMTestBase {
         assertEq(psmHarness.getAssetValue(address(usdc), 2e6, true), psmHarness.getUsdcValue(2e6));
         assertEq(psmHarness.getAssetValue(address(usdc), 3e6, true), psmHarness.getUsdcValue(3e6));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1, false), psmHarness.getUsdsValue(1));
-        assertEq(psmHarness.getAssetValue(address(dai), 2, false), psmHarness.getUsdsValue(2));
-        assertEq(psmHarness.getAssetValue(address(dai), 3, false), psmHarness.getUsdsValue(3));
+        assertEq(psmHarness.getAssetValue(address(usds), 1, false), psmHarness.getUsdsValue(1));
+        assertEq(psmHarness.getAssetValue(address(usds), 2, false), psmHarness.getUsdsValue(2));
+        assertEq(psmHarness.getAssetValue(address(usds), 3, false), psmHarness.getUsdsValue(3));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1, true), psmHarness.getUsdsValue(1));
-        assertEq(psmHarness.getAssetValue(address(dai), 2, true), psmHarness.getUsdsValue(2));
-        assertEq(psmHarness.getAssetValue(address(dai), 3, true), psmHarness.getUsdsValue(3));
+        assertEq(psmHarness.getAssetValue(address(usds), 1, true), psmHarness.getUsdsValue(1));
+        assertEq(psmHarness.getAssetValue(address(usds), 2, true), psmHarness.getUsdsValue(2));
+        assertEq(psmHarness.getAssetValue(address(usds), 3, true), psmHarness.getUsdsValue(3));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1e18, false), psmHarness.getUsdsValue(1e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 2e18, false), psmHarness.getUsdsValue(2e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 3e18, false), psmHarness.getUsdsValue(3e18));
+        assertEq(psmHarness.getAssetValue(address(usds), 1e18, false), psmHarness.getUsdsValue(1e18));
+        assertEq(psmHarness.getAssetValue(address(usds), 2e18, false), psmHarness.getUsdsValue(2e18));
+        assertEq(psmHarness.getAssetValue(address(usds), 3e18, false), psmHarness.getUsdsValue(3e18));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1e18, true), psmHarness.getUsdsValue(1e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 2e18, true), psmHarness.getUsdsValue(2e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 3e18, true), psmHarness.getUsdsValue(3e18));
+        assertEq(psmHarness.getAssetValue(address(usds), 1e18, true), psmHarness.getUsdsValue(1e18));
+        assertEq(psmHarness.getAssetValue(address(usds), 2e18, true), psmHarness.getUsdsValue(2e18));
+        assertEq(psmHarness.getAssetValue(address(usds), 3e18, true), psmHarness.getUsdsValue(3e18));
 
-        assertEq(psmHarness.getAssetValue(address(sDai), 1, false), psmHarness.getSUsdsValue(1, false));
-        assertEq(psmHarness.getAssetValue(address(sDai), 2, false), psmHarness.getSUsdsValue(2, false));
-        assertEq(psmHarness.getAssetValue(address(sDai), 3, false), psmHarness.getSUsdsValue(3, false));
+        assertEq(psmHarness.getAssetValue(address(susds), 1, false), psmHarness.getSUsdsValue(1, false));
+        assertEq(psmHarness.getAssetValue(address(susds), 2, false), psmHarness.getSUsdsValue(2, false));
+        assertEq(psmHarness.getAssetValue(address(susds), 3, false), psmHarness.getSUsdsValue(3, false));
 
-        assertEq(psmHarness.getAssetValue(address(sDai), 1e18, false), psmHarness.getSUsdsValue(1e18, false));
-        assertEq(psmHarness.getAssetValue(address(sDai), 2e18, false), psmHarness.getSUsdsValue(2e18, false));
-        assertEq(psmHarness.getAssetValue(address(sDai), 3e18, false), psmHarness.getSUsdsValue(3e18, false));
+        assertEq(psmHarness.getAssetValue(address(susds), 1e18, false), psmHarness.getSUsdsValue(1e18, false));
+        assertEq(psmHarness.getAssetValue(address(susds), 2e18, false), psmHarness.getSUsdsValue(2e18, false));
+        assertEq(psmHarness.getAssetValue(address(susds), 3e18, false), psmHarness.getSUsdsValue(3e18, false));
 
-        assertEq(psmHarness.getAssetValue(address(sDai), 1, true), psmHarness.getSUsdsValue(1, true));
-        assertEq(psmHarness.getAssetValue(address(sDai), 2, true), psmHarness.getSUsdsValue(2, true));
-        assertEq(psmHarness.getAssetValue(address(sDai), 3, true), psmHarness.getSUsdsValue(3, true));
+        assertEq(psmHarness.getAssetValue(address(susds), 1, true), psmHarness.getSUsdsValue(1, true));
+        assertEq(psmHarness.getAssetValue(address(susds), 2, true), psmHarness.getSUsdsValue(2, true));
+        assertEq(psmHarness.getAssetValue(address(susds), 3, true), psmHarness.getSUsdsValue(3, true));
 
-        assertEq(psmHarness.getAssetValue(address(sDai), 1e18, true), psmHarness.getSUsdsValue(1e18, true));
-        assertEq(psmHarness.getAssetValue(address(sDai), 2e18, true), psmHarness.getSUsdsValue(2e18, true));
-        assertEq(psmHarness.getAssetValue(address(sDai), 3e18, true), psmHarness.getSUsdsValue(3e18, true));
+        assertEq(psmHarness.getAssetValue(address(susds), 1e18, true), psmHarness.getSUsdsValue(1e18, true));
+        assertEq(psmHarness.getAssetValue(address(susds), 2e18, true), psmHarness.getSUsdsValue(2e18, true));
+        assertEq(psmHarness.getAssetValue(address(susds), 3e18, true), psmHarness.getSUsdsValue(3e18, true));
     }
 
     function testFuzz_getAssetValue(uint256 amount) public view {
-        amount = _bound(amount, 0, SDAI_TOKEN_MAX);
+        amount = _bound(amount, 0, SUSDS_TOKEN_MAX);
 
         // `usdc` and `usds` return the same values whether `roundUp` is true or false
-        assertEq(psmHarness.getAssetValue(address(usdc), amount, true),  psmHarness.getUsdcValue(amount));
-        assertEq(psmHarness.getAssetValue(address(usdc), amount, true),  psmHarness.getUsdcValue(amount));
-        assertEq(psmHarness.getAssetValue(address(dai),  amount, false), psmHarness.getUsdsValue(amount));
-        assertEq(psmHarness.getAssetValue(address(dai),  amount, false), psmHarness.getUsdsValue(amount));
+        assertEq(psmHarness.getAssetValue(address(usdc),  amount, true),  psmHarness.getUsdcValue(amount));
+        assertEq(psmHarness.getAssetValue(address(usdc),  amount, true),  psmHarness.getUsdcValue(amount));
+        assertEq(psmHarness.getAssetValue(address(usds),  amount, false), psmHarness.getUsdsValue(amount));
+        assertEq(psmHarness.getAssetValue(address(usds),  amount, false), psmHarness.getUsdsValue(amount));
 
         // `susds` returns different values depending on the value of `roundUp`, but always same as underlying function
-        assertEq(psmHarness.getAssetValue(address(sDai), amount, false), psmHarness.getSUsdsValue(amount, false));
-        assertEq(psmHarness.getAssetValue(address(sDai), amount, true),  psmHarness.getSUsdsValue(amount, true));
+        assertEq(psmHarness.getAssetValue(address(susds), amount, false), psmHarness.getSUsdsValue(amount, false));
+        assertEq(psmHarness.getAssetValue(address(susds), amount, true),  psmHarness.getSUsdsValue(amount, true));
     }
 
     function test_getAssetValue_zeroAddress() public {
@@ -217,7 +217,7 @@ contract PSMHarnessTests is PSMTestBase {
 contract GetPsmTotalValueTests is PSMTestBase {
 
     function test_totalAssets_balanceChanges() public {
-        dai.mint(address(psm), 1e18);
+        usds.mint(address(psm), 1e18);
 
         assertEq(psm.totalAssets(), 1e18);
 
@@ -225,11 +225,11 @@ contract GetPsmTotalValueTests is PSMTestBase {
 
         assertEq(psm.totalAssets(), 2e18);
 
-        sDai.mint(address(psm), 1e18);
+        susds.mint(address(psm), 1e18);
 
         assertEq(psm.totalAssets(), 3.25e18);
 
-        dai.burn(address(psm), 1e18);
+        usds.burn(address(psm), 1e18);
 
         assertEq(psm.totalAssets(), 2.25e18);
 
@@ -237,7 +237,7 @@ contract GetPsmTotalValueTests is PSMTestBase {
 
         assertEq(psm.totalAssets(), 1.25e18);
 
-        sDai.burn(address(psm), 1e18);
+        susds.burn(address(psm), 1e18);
 
         assertEq(psm.totalAssets(), 0);
     }
@@ -245,9 +245,9 @@ contract GetPsmTotalValueTests is PSMTestBase {
     function test_totalAssets_conversionRateChanges() public {
         assertEq(psm.totalAssets(), 0);
 
-        dai.mint(address(psm),  1e18);
+        usds.mint(address(psm),  1e18);
         usdc.mint(address(psm), 1e6);
-        sDai.mint(address(psm), 1e18);
+        susds.mint(address(psm), 1e18);
 
         assertEq(psm.totalAssets(), 3.25e18);
 
@@ -263,9 +263,9 @@ contract GetPsmTotalValueTests is PSMTestBase {
     function test_totalAssets_bothChange() public {
         assertEq(psm.totalAssets(), 0);
 
-        dai.mint(address(psm),  1e18);
+        usds.mint(address(psm),  1e18);
         usdc.mint(address(psm), 1e6);
-        sDai.mint(address(psm), 1e18);
+        susds.mint(address(psm), 1e18);
 
         assertEq(psm.totalAssets(), 3.25e18);
 
@@ -273,33 +273,33 @@ contract GetPsmTotalValueTests is PSMTestBase {
 
         assertEq(psm.totalAssets(), 3.5e18);
 
-        sDai.mint(address(psm), 1e18);
+        susds.mint(address(psm), 1e18);
 
         assertEq(psm.totalAssets(), 5e18);
     }
 
     function testFuzz_totalAssets(
-        uint256 daiAmount,
+        uint256 usdsAmount,
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
     {
-        daiAmount      = _bound(daiAmount,      0,         DAI_TOKEN_MAX);
+        usdsAmount     = _bound(usdsAmount,     0,         USDS_TOKEN_MAX);
         usdcAmount     = _bound(usdcAmount,     0,         USDC_TOKEN_MAX);
-        sDaiAmount     = _bound(sDaiAmount,     0,         SDAI_TOKEN_MAX);
+        susdsAmount    = _bound(susdsAmount,    0,         SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);
 
-        dai.mint(address(psm),  daiAmount);
-        usdc.mint(address(psm), usdcAmount);
-        sDai.mint(address(psm), sDaiAmount);
+        usds.mint(address(psm),  usdsAmount);
+        usdc.mint(address(psm),  usdcAmount);
+        susds.mint(address(psm), susdsAmount);
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         assertEq(
             psm.totalAssets(),
-            daiAmount + (usdcAmount * 1e12) + (sDaiAmount * conversionRate / 1e27)
+            usdsAmount + (usdcAmount * 1e12) + (susdsAmount * conversionRate / 1e27)
         );
     }
 

--- a/test/unit/Getters.t.sol
+++ b/test/unit/Getters.t.sol
@@ -14,7 +14,7 @@ contract PSMHarnessTests is PSMTestBase {
     function setUp() public override {
         super.setUp();
         psmHarness = new PSM3Harness(
-            address(admin),
+            address(owner),
             address(dai),
             address(usdc),
             address(sDai),

--- a/test/unit/Getters.t.sol
+++ b/test/unit/Getters.t.sol
@@ -15,51 +15,51 @@ contract PSMHarnessTests is PSMTestBase {
         super.setUp();
         psmHarness = new PSM3Harness(
             address(owner),
-            address(dai),
             address(usdc),
+            address(dai),
             address(sDai),
             address(rateProvider)
         );
     }
 
-    function test_getAsset0Value() public view {
-        assertEq(psmHarness.getAsset0Value(1), 1);
-        assertEq(psmHarness.getAsset0Value(2), 2);
-        assertEq(psmHarness.getAsset0Value(3), 3);
-
-        assertEq(psmHarness.getAsset0Value(100e18), 100e18);
-        assertEq(psmHarness.getAsset0Value(200e18), 200e18);
-        assertEq(psmHarness.getAsset0Value(300e18), 300e18);
-
-        assertEq(psmHarness.getAsset0Value(100_000_000_000e18), 100_000_000_000e18);
-        assertEq(psmHarness.getAsset0Value(200_000_000_000e18), 200_000_000_000e18);
-        assertEq(psmHarness.getAsset0Value(300_000_000_000e18), 300_000_000_000e18);
-    }
-
-    function testFuzz_getAsset0Value(uint256 amount) public view {
-        amount = _bound(amount, 0, 1e45);
-
-        assertEq(psmHarness.getAsset0Value(amount), amount);
-    }
-
     function test_getAsset1Value() public view {
-        assertEq(psmHarness.getAsset1Value(1), 1e12);
-        assertEq(psmHarness.getAsset1Value(2), 2e12);
-        assertEq(psmHarness.getAsset1Value(3), 3e12);
+        assertEq(psmHarness.getAsset1Value(1), 1);
+        assertEq(psmHarness.getAsset1Value(2), 2);
+        assertEq(psmHarness.getAsset1Value(3), 3);
 
-        assertEq(psmHarness.getAsset1Value(100e6), 100e18);
-        assertEq(psmHarness.getAsset1Value(200e6), 200e18);
-        assertEq(psmHarness.getAsset1Value(300e6), 300e18);
+        assertEq(psmHarness.getAsset1Value(100e18), 100e18);
+        assertEq(psmHarness.getAsset1Value(200e18), 200e18);
+        assertEq(psmHarness.getAsset1Value(300e18), 300e18);
 
-        assertEq(psmHarness.getAsset1Value(100_000_000_000e6), 100_000_000_000e18);
-        assertEq(psmHarness.getAsset1Value(200_000_000_000e6), 200_000_000_000e18);
-        assertEq(psmHarness.getAsset1Value(300_000_000_000e6), 300_000_000_000e18);
+        assertEq(psmHarness.getAsset1Value(100_000_000_000e18), 100_000_000_000e18);
+        assertEq(psmHarness.getAsset1Value(200_000_000_000e18), 200_000_000_000e18);
+        assertEq(psmHarness.getAsset1Value(300_000_000_000e18), 300_000_000_000e18);
     }
 
     function testFuzz_getAsset1Value(uint256 amount) public view {
         amount = _bound(amount, 0, 1e45);
 
-        assertEq(psmHarness.getAsset1Value(amount), amount * 1e12);
+        assertEq(psmHarness.getAsset1Value(amount), amount);
+    }
+
+    function test_getAsset0Value() public view {
+        assertEq(psmHarness.getAsset0Value(1), 1e12);
+        assertEq(psmHarness.getAsset0Value(2), 2e12);
+        assertEq(psmHarness.getAsset0Value(3), 3e12);
+
+        assertEq(psmHarness.getAsset0Value(100e6), 100e18);
+        assertEq(psmHarness.getAsset0Value(200e6), 200e18);
+        assertEq(psmHarness.getAsset0Value(300e6), 300e18);
+
+        assertEq(psmHarness.getAsset0Value(100_000_000_000e6), 100_000_000_000e18);
+        assertEq(psmHarness.getAsset0Value(200_000_000_000e6), 200_000_000_000e18);
+        assertEq(psmHarness.getAsset0Value(300_000_000_000e6), 300_000_000_000e18);
+    }
+
+    function testFuzz_getAsset0Value(uint256 amount) public view {
+        amount = _bound(amount, 0, 1e45);
+
+        assertEq(psmHarness.getAsset0Value(amount), amount * 1e12);
     }
 
     function test_getAsset2Value() public {
@@ -144,37 +144,37 @@ contract PSMHarnessTests is PSMTestBase {
     }
 
     function test_getAssetValue() public view {
-        assertEq(psmHarness.getAssetValue(address(dai), 1, false), psmHarness.getAsset0Value(1));
-        assertEq(psmHarness.getAssetValue(address(dai), 2, false), psmHarness.getAsset0Value(2));
-        assertEq(psmHarness.getAssetValue(address(dai), 3, false), psmHarness.getAsset0Value(3));
+        assertEq(psmHarness.getAssetValue(address(usdc), 1, false), psmHarness.getAsset0Value(1));
+        assertEq(psmHarness.getAssetValue(address(usdc), 2, false), psmHarness.getAsset0Value(2));
+        assertEq(psmHarness.getAssetValue(address(usdc), 3, false), psmHarness.getAsset0Value(3));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1, true), psmHarness.getAsset0Value(1));
-        assertEq(psmHarness.getAssetValue(address(dai), 2, true), psmHarness.getAsset0Value(2));
-        assertEq(psmHarness.getAssetValue(address(dai), 3, true), psmHarness.getAsset0Value(3));
+        assertEq(psmHarness.getAssetValue(address(usdc), 1, true), psmHarness.getAsset0Value(1));
+        assertEq(psmHarness.getAssetValue(address(usdc), 2, true), psmHarness.getAsset0Value(2));
+        assertEq(psmHarness.getAssetValue(address(usdc), 3, true), psmHarness.getAsset0Value(3));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1e18, false), psmHarness.getAsset0Value(1e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 2e18, false), psmHarness.getAsset0Value(2e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 3e18, false), psmHarness.getAsset0Value(3e18));
+        assertEq(psmHarness.getAssetValue(address(usdc), 1e6, false), psmHarness.getAsset0Value(1e6));
+        assertEq(psmHarness.getAssetValue(address(usdc), 2e6, false), psmHarness.getAsset0Value(2e6));
+        assertEq(psmHarness.getAssetValue(address(usdc), 3e6, false), psmHarness.getAsset0Value(3e6));
 
-        assertEq(psmHarness.getAssetValue(address(dai), 1e18, true), psmHarness.getAsset0Value(1e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 2e18, true), psmHarness.getAsset0Value(2e18));
-        assertEq(psmHarness.getAssetValue(address(dai), 3e18, true), psmHarness.getAsset0Value(3e18));
+        assertEq(psmHarness.getAssetValue(address(usdc), 1e6, true), psmHarness.getAsset0Value(1e6));
+        assertEq(psmHarness.getAssetValue(address(usdc), 2e6, true), psmHarness.getAsset0Value(2e6));
+        assertEq(psmHarness.getAssetValue(address(usdc), 3e6, true), psmHarness.getAsset0Value(3e6));
 
-        assertEq(psmHarness.getAssetValue(address(usdc), 1, false), psmHarness.getAsset1Value(1));
-        assertEq(psmHarness.getAssetValue(address(usdc), 2, false), psmHarness.getAsset1Value(2));
-        assertEq(psmHarness.getAssetValue(address(usdc), 3, false), psmHarness.getAsset1Value(3));
+        assertEq(psmHarness.getAssetValue(address(dai), 1, false), psmHarness.getAsset1Value(1));
+        assertEq(psmHarness.getAssetValue(address(dai), 2, false), psmHarness.getAsset1Value(2));
+        assertEq(psmHarness.getAssetValue(address(dai), 3, false), psmHarness.getAsset1Value(3));
 
-        assertEq(psmHarness.getAssetValue(address(usdc), 1, true), psmHarness.getAsset1Value(1));
-        assertEq(psmHarness.getAssetValue(address(usdc), 2, true), psmHarness.getAsset1Value(2));
-        assertEq(psmHarness.getAssetValue(address(usdc), 3, true), psmHarness.getAsset1Value(3));
+        assertEq(psmHarness.getAssetValue(address(dai), 1, true), psmHarness.getAsset1Value(1));
+        assertEq(psmHarness.getAssetValue(address(dai), 2, true), psmHarness.getAsset1Value(2));
+        assertEq(psmHarness.getAssetValue(address(dai), 3, true), psmHarness.getAsset1Value(3));
 
-        assertEq(psmHarness.getAssetValue(address(usdc), 1e6, false), psmHarness.getAsset1Value(1e6));
-        assertEq(psmHarness.getAssetValue(address(usdc), 2e6, false), psmHarness.getAsset1Value(2e6));
-        assertEq(psmHarness.getAssetValue(address(usdc), 3e6, false), psmHarness.getAsset1Value(3e6));
+        assertEq(psmHarness.getAssetValue(address(dai), 1e18, false), psmHarness.getAsset1Value(1e18));
+        assertEq(psmHarness.getAssetValue(address(dai), 2e18, false), psmHarness.getAsset1Value(2e18));
+        assertEq(psmHarness.getAssetValue(address(dai), 3e18, false), psmHarness.getAsset1Value(3e18));
 
-        assertEq(psmHarness.getAssetValue(address(usdc), 1e6, true), psmHarness.getAsset1Value(1e6));
-        assertEq(psmHarness.getAssetValue(address(usdc), 2e6, true), psmHarness.getAsset1Value(2e6));
-        assertEq(psmHarness.getAssetValue(address(usdc), 3e6, true), psmHarness.getAsset1Value(3e6));
+        assertEq(psmHarness.getAssetValue(address(dai), 1e18, true), psmHarness.getAsset1Value(1e18));
+        assertEq(psmHarness.getAssetValue(address(dai), 2e18, true), psmHarness.getAsset1Value(2e18));
+        assertEq(psmHarness.getAssetValue(address(dai), 3e18, true), psmHarness.getAsset1Value(3e18));
 
         assertEq(psmHarness.getAssetValue(address(sDai), 1, false), psmHarness.getAsset2Value(1, false));
         assertEq(psmHarness.getAssetValue(address(sDai), 2, false), psmHarness.getAsset2Value(2, false));
@@ -197,10 +197,10 @@ contract PSMHarnessTests is PSMTestBase {
         amount = _bound(amount, 0, SDAI_TOKEN_MAX);
 
         // `asset0` and `asset1` return the same values whether `roundUp` is true or false
-        assertEq(psmHarness.getAssetValue(address(dai),  amount, false), psmHarness.getAsset0Value(amount));
-        assertEq(psmHarness.getAssetValue(address(dai),  amount, false), psmHarness.getAsset0Value(amount));
-        assertEq(psmHarness.getAssetValue(address(usdc), amount, true),  psmHarness.getAsset1Value(amount));
-        assertEq(psmHarness.getAssetValue(address(usdc), amount, true),  psmHarness.getAsset1Value(amount));
+        assertEq(psmHarness.getAssetValue(address(usdc), amount, true),  psmHarness.getAsset0Value(amount));
+        assertEq(psmHarness.getAssetValue(address(usdc), amount, true),  psmHarness.getAsset0Value(amount));
+        assertEq(psmHarness.getAssetValue(address(dai),  amount, false), psmHarness.getAsset1Value(amount));
+        assertEq(psmHarness.getAssetValue(address(dai),  amount, false), psmHarness.getAsset1Value(amount));
 
         // `asset2` returns different values depending on the value of `roundUp`, but always same as underlying function
         assertEq(psmHarness.getAssetValue(address(sDai), amount, false), psmHarness.getAsset2Value(amount, false));

--- a/test/unit/InflationAttack.t.sol
+++ b/test/unit/InflationAttack.t.sol
@@ -11,42 +11,42 @@ contract InflationAttackTests is PSMTestBase {
     address frontRunner    = makeAddr("frontRunner");
     address deployer       = makeAddr("deployer");
 
-    function test_inflationAttack_noInitialDeposit_sDai() public {
-        // Step 1: Front runner deposits 1 sDAI to get 1 share
+    function test_inflationAttack_noInitialDeposit_susds() public {
+        // Step 1: Front runner deposits 1 sUSDS to get 1 share
 
-        // Have to use sDai because 1 USDC mints 1e12 shares
-        _deposit(address(sDai), frontRunner, 1);
-
-        _runInflationAttack_noInitialDepositTest();
-    }
-
-    function test_inflationAttack_noInitialDeposit_dai() public {
-        // Step 1: Front runner deposits 1 sDAI to get 1 share
-
-        // Have to use DAI because 1 USDC mints 1e12 shares
-        _deposit(address(dai), frontRunner, 1);
+        // Have to use susds because 1 USDC mints 1e12 shares
+        _deposit(address(susds), frontRunner, 1);
 
         _runInflationAttack_noInitialDepositTest();
     }
 
-    function test_inflationAttack_useInitialDeposit_sDai() public {
-        _deposit(address(sDai), address(deployer), 0.8e18);  // 1e18 shares
+    function test_inflationAttack_noInitialDeposit_usds() public {
+        // Step 1: Front runner deposits 1 sUSDS to get 1 share
 
-        // Step 1: Front runner deposits sDAI to get 1 share
+        // Have to use USDS because 1 USDC mints 1e12 shares
+        _deposit(address(usds), frontRunner, 1);
 
-        // User tries to do the same attack, depositing one sDAI for 1 share
-        _deposit(address(sDai), frontRunner, 1);
+        _runInflationAttack_noInitialDepositTest();
+    }
+
+    function test_inflationAttack_useInitialDeposit_susds() public {
+        _deposit(address(susds), address(deployer), 0.8e18);  // 1e18 shares
+
+        // Step 1: Front runner deposits sUSDS to get 1 share
+
+        // User tries to do the same attack, depositing one sUSDS for 1 share
+        _deposit(address(susds), frontRunner, 1);
 
         _runInflationAttack_useInitialDepositTest();
     }
 
-    function test_inflationAttack_useInitialDeposit_dai() public {
-        _deposit(address(dai), address(deployer), 1e18);  // 1e18 shares
+    function test_inflationAttack_useInitialDeposit_usds() public {
+        _deposit(address(usds), address(deployer), 1e18);  // 1e18 shares
 
-        // Step 1: Front runner deposits dai to get 1 share
+        // Step 1: Front runner deposits usds to get 1 share
 
-        // User tries to do the same attack, depositing one sDAI for 1 share
-        _deposit(address(dai), frontRunner, 1);
+        // User tries to do the same attack, depositing one sUSDS for 1 share
+        _deposit(address(usds), frontRunner, 1);
 
         _runInflationAttack_useInitialDepositTest();
     }

--- a/test/unit/PreviewDeposit.t.sol
+++ b/test/unit/PreviewDeposit.t.sol
@@ -18,19 +18,19 @@ contract PSMPreviewDeposit_SuccessTests is PSMTestBase {
 
     address depositor = makeAddr("depositor");
 
-    function test_previewDeposit_dai_firstDeposit() public view {
-        assertEq(psm.previewDeposit(address(dai), 1), 1);
-        assertEq(psm.previewDeposit(address(dai), 2), 2);
-        assertEq(psm.previewDeposit(address(dai), 3), 3);
+    function test_previewDeposit_usds_firstDeposit() public view {
+        assertEq(psm.previewDeposit(address(usds), 1), 1);
+        assertEq(psm.previewDeposit(address(usds), 2), 2);
+        assertEq(psm.previewDeposit(address(usds), 3), 3);
 
-        assertEq(psm.previewDeposit(address(dai), 1e18), 1e18);
-        assertEq(psm.previewDeposit(address(dai), 2e18), 2e18);
-        assertEq(psm.previewDeposit(address(dai), 3e18), 3e18);
+        assertEq(psm.previewDeposit(address(usds), 1e18), 1e18);
+        assertEq(psm.previewDeposit(address(usds), 2e18), 2e18);
+        assertEq(psm.previewDeposit(address(usds), 3e18), 3e18);
     }
 
-    function testFuzz_previewDeposit_dai_firstDeposit(uint256 amount) public view {
-        amount = _bound(amount, 0, DAI_TOKEN_MAX);
-        assertEq(psm.previewDeposit(address(dai), amount), amount);
+    function testFuzz_previewDeposit_usds_firstDeposit(uint256 amount) public view {
+        amount = _bound(amount, 0, USDS_TOKEN_MAX);
+        assertEq(psm.previewDeposit(address(usds), amount), amount);
     }
 
     function test_previewDeposit_usdc_firstDeposit() public view {
@@ -48,43 +48,43 @@ contract PSMPreviewDeposit_SuccessTests is PSMTestBase {
         assertEq(psm.previewDeposit(address(usdc), amount), amount * 1e12);
     }
 
-    function test_previewDeposit_sDai_firstDeposit() public view {
-        assertEq(psm.previewDeposit(address(sDai), 1), 1);
-        assertEq(psm.previewDeposit(address(sDai), 2), 2);
-        assertEq(psm.previewDeposit(address(sDai), 3), 3);
-        assertEq(psm.previewDeposit(address(sDai), 4), 5);
+    function test_previewDeposit_susds_firstDeposit() public view {
+        assertEq(psm.previewDeposit(address(susds), 1), 1);
+        assertEq(psm.previewDeposit(address(susds), 2), 2);
+        assertEq(psm.previewDeposit(address(susds), 3), 3);
+        assertEq(psm.previewDeposit(address(susds), 4), 5);
 
-        assertEq(psm.previewDeposit(address(sDai), 1e18), 1.25e18);
-        assertEq(psm.previewDeposit(address(sDai), 2e18), 2.50e18);
-        assertEq(psm.previewDeposit(address(sDai), 3e18), 3.75e18);
-        assertEq(psm.previewDeposit(address(sDai), 4e18), 5.00e18);
+        assertEq(psm.previewDeposit(address(susds), 1e18), 1.25e18);
+        assertEq(psm.previewDeposit(address(susds), 2e18), 2.50e18);
+        assertEq(psm.previewDeposit(address(susds), 3e18), 3.75e18);
+        assertEq(psm.previewDeposit(address(susds), 4e18), 5.00e18);
     }
 
-    function testFuzz_previewDeposit_sDai_firstDeposit(uint256 amount) public view {
-        amount = _bound(amount, 0, SDAI_TOKEN_MAX);
-        assertEq(psm.previewDeposit(address(sDai), amount), amount * 1.25e27 / 1e27);
+    function testFuzz_previewDeposit_susds_firstDeposit(uint256 amount) public view {
+        amount = _bound(amount, 0, SUSDS_TOKEN_MAX);
+        assertEq(psm.previewDeposit(address(susds), amount), amount * 1.25e27 / 1e27);
     }
 
     function test_previewDeposit_afterDepositsAndExchangeRateIncrease() public {
         _assertOneToOne();
 
-        _deposit(address(dai), depositor, 1e18);
+        _deposit(address(usds), depositor, 1e18);
         _assertOneToOne();
 
         _deposit(address(usdc), depositor, 1e6);
         _assertOneToOne();
 
-        _deposit(address(sDai), depositor, 0.8e18);
+        _deposit(address(susds), depositor, 0.8e18);
         _assertOneToOne();
 
         mockRateProvider.__setConversionRate(2e27);
 
         // $300 dollars of value deposited, 300 shares minted.
-        // sDAI portion becomes worth $160, full pool worth $360, each share worth $1.20
+        // sUSDS portion becomes worth $160, full pool worth $360, each share worth $1.20
         // 1 USDC = 1/1.20 = 0.833...
-        assertEq(psm.previewDeposit(address(dai),  1e18), 0.833333333333333333e18);
-        assertEq(psm.previewDeposit(address(usdc), 1e6),  0.833333333333333333e18);
-        assertEq(psm.previewDeposit(address(sDai), 1e18), 1.666666666666666666e18);  // 1 sDAI = $2
+        assertEq(psm.previewDeposit(address(usds),  1e18), 0.833333333333333333e18);
+        assertEq(psm.previewDeposit(address(usdc),  1e6),  0.833333333333333333e18);
+        assertEq(psm.previewDeposit(address(susds), 1e18), 1.666666666666666666e18);  // 1 sUSDS = $2
     }
 
     function testFuzz_previewDeposit_afterDepositsAndExchangeRateIncrease(
@@ -94,21 +94,21 @@ contract PSMPreviewDeposit_SuccessTests is PSMTestBase {
         uint256 conversionRate,
         uint256 previewAmount
     ) public {
-        amount1        = _bound(amount1,        1,       DAI_TOKEN_MAX);
+        amount1        = _bound(amount1,        1,       USDS_TOKEN_MAX);
         amount2        = _bound(amount2,        1,       USDC_TOKEN_MAX);
-        amount3        = _bound(amount3,        1,       SDAI_TOKEN_MAX);
+        amount3        = _bound(amount3,        1,       SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 1.00e27, 1000e27);
-        previewAmount  = _bound(previewAmount,  0,       DAI_TOKEN_MAX);
+        previewAmount  = _bound(previewAmount,  0,       USDS_TOKEN_MAX);
 
         _assertOneToOne();
 
-        _deposit(address(dai), depositor, amount1);
+        _deposit(address(usds), depositor, amount1);
         _assertOneToOne();
 
         _deposit(address(usdc), depositor, amount2);
         _assertOneToOne();
 
-        _deposit(address(sDai), depositor, amount3);
+        _deposit(address(susds), depositor, amount3);
         _assertOneToOne();
 
         mockRateProvider.__setConversionRate(conversionRate);
@@ -117,15 +117,15 @@ contract PSMPreviewDeposit_SuccessTests is PSMTestBase {
         uint256 totalValue        = amount1 + amount2 * 1e12 + amount3 * conversionRate / 1e27;
         uint256 usdcPreviewAmount = previewAmount / 1e12;
 
-        assertEq(psm.previewDeposit(address(dai),  previewAmount),     previewAmount                           * totalSharesMinted / totalValue);
-        assertEq(psm.previewDeposit(address(usdc), usdcPreviewAmount), usdcPreviewAmount * 1e12                * totalSharesMinted / totalValue);  // Divide then multiply to replicate rounding
-        assertEq(psm.previewDeposit(address(sDai), previewAmount),     (previewAmount * conversionRate / 1e27) * totalSharesMinted / totalValue);
+        assertEq(psm.previewDeposit(address(usds),  previewAmount),     previewAmount                           * totalSharesMinted / totalValue);
+        assertEq(psm.previewDeposit(address(usdc),  usdcPreviewAmount), usdcPreviewAmount * 1e12                * totalSharesMinted / totalValue);  // Divide then multiply to replicate rounding
+        assertEq(psm.previewDeposit(address(susds), previewAmount),     (previewAmount * conversionRate / 1e27) * totalSharesMinted / totalValue);
     }
 
     function _assertOneToOne() internal view {
-        assertEq(psm.previewDeposit(address(dai),  1e18), 1e18);
-        assertEq(psm.previewDeposit(address(usdc), 1e6),  1e18);
-        assertEq(psm.previewDeposit(address(sDai), 1e18), 1.25e18);
+        assertEq(psm.previewDeposit(address(usds),  1e18), 1e18);
+        assertEq(psm.previewDeposit(address(usdc),  1e6),  1e18);
+        assertEq(psm.previewDeposit(address(susds), 1e18), 1.25e18);
     }
 
 }

--- a/test/unit/PreviewWIthdraw.t.sol
+++ b/test/unit/PreviewWIthdraw.t.sol
@@ -18,9 +18,9 @@ contract PSMPreviewWithdraw_ZeroAssetsTests is PSMTestBase {
 
     // Always returns zero because there is no balance of assets in the PSM in this case
     function test_previewWithdraw_zeroTotalAssets() public {
-        ( uint256 shares1, uint256 assets1 ) = psm.previewWithdraw(address(dai),  1e18);
-        ( uint256 shares2, uint256 assets2 ) = psm.previewWithdraw(address(usdc), 1e6);
-        ( uint256 shares3, uint256 assets3 ) = psm.previewWithdraw(address(sDai), 1e18);
+        ( uint256 shares1, uint256 assets1 ) = psm.previewWithdraw(address(usds),  1e18);
+        ( uint256 shares2, uint256 assets2 ) = psm.previewWithdraw(address(usdc),  1e6);
+        ( uint256 shares3, uint256 assets3 ) = psm.previewWithdraw(address(susds), 1e18);
 
         assertEq(shares1, 0);
         assertEq(assets1, 0);
@@ -31,9 +31,9 @@ contract PSMPreviewWithdraw_ZeroAssetsTests is PSMTestBase {
 
         mockRateProvider.__setConversionRate(2e27);
 
-        ( shares1, assets1 ) = psm.previewWithdraw(address(dai),  1e18);
-        ( shares2, assets2 ) = psm.previewWithdraw(address(usdc), 1e6);
-        ( shares3, assets3 ) = psm.previewWithdraw(address(sDai), 1e18);
+        ( shares1, assets1 ) = psm.previewWithdraw(address(usds),  1e18);
+        ( shares2, assets2 ) = psm.previewWithdraw(address(usdc),  1e6);
+        ( shares3, assets3 ) = psm.previewWithdraw(address(susds), 1e18);
 
         assertEq(shares1, 0);
         assertEq(assets1, 0);
@@ -50,26 +50,26 @@ contract PSMPreviewWithdraw_SuccessTests is PSMTestBase {
     function setUp() public override {
         super.setUp();
         // Setup so that address(this) has the most shares, higher underlying balance than PSM
-        // balance of sDAI and USDC
-        _deposit(address(dai),  address(this),         100e18);
-        _deposit(address(usdc), makeAddr("usdc-user"), 10e6);
-        _deposit(address(sDai), makeAddr("sDai-user"), 1e18);
+        // balance of sUSDS and USDC
+        _deposit(address(usds),  address(this),          100e18);
+        _deposit(address(usdc),  makeAddr("usdc-user"),  10e6);
+        _deposit(address(susds), makeAddr("susds-user"), 1e18);
     }
 
-    function test_previewWithdraw_dai_amountLtUnderlyingBalance() public view {
-        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(dai), 100e18 - 1);
+    function test_previewWithdraw_usds_amountLtUnderlyingBalance() public view {
+        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(usds), 100e18 - 1);
         assertEq(shares, 100e18 - 1);
         assertEq(assets, 100e18 - 1);
     }
 
-    function test_previewWithdraw_dai_amountEqUnderlyingBalance() public view {
-        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(dai), 100e18);
+    function test_previewWithdraw_usds_amountEqUnderlyingBalance() public view {
+        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(usds), 100e18);
         assertEq(shares, 100e18);
         assertEq(assets, 100e18);
     }
 
-    function test_previewWithdraw_dai_amountGtUnderlyingBalance() public view {
-        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(dai), 100e18 + 1);
+    function test_previewWithdraw_usds_amountGtUnderlyingBalance() public view {
+        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(usds), 100e18 + 1);
         assertEq(shares, 100e18);
         assertEq(assets, 100e18);
     }
@@ -92,20 +92,20 @@ contract PSMPreviewWithdraw_SuccessTests is PSMTestBase {
         assertEq(assets, 10e6);
     }
 
-    function test_previewWithdraw_sdai_amountLtUnderlyingBalanceAndLtPsmBalance() public view {
-        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(sDai), 1e18 - 1);
+    function test_previewWithdraw_susds_amountLtUnderlyingBalanceAndLtPsmBalance() public view {
+        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(susds), 1e18 - 1);
         assertEq(shares, 1.25e18 - 1);
         assertEq(assets, 1e18 - 1);
     }
 
-    function test_previewWithdraw_sdai_amountLtUnderlyingBalanceAndEqPsmBalance() public view {
-        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(sDai), 1e18);
+    function test_previewWithdraw_susds_amountLtUnderlyingBalanceAndEqPsmBalance() public view {
+        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(susds), 1e18);
         assertEq(shares, 1.25e18);
         assertEq(assets, 1e18);
     }
 
-    function test_previewWithdraw_sdai_amountLtUnderlyingBalanceAndGtPsmBalance() public view {
-        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(sDai), 1e18 + 1);
+    function test_previewWithdraw_susds_amountLtUnderlyingBalanceAndGtPsmBalance() public view {
+        ( uint256 shares, uint256 assets ) = psm.previewWithdraw(address(susds), 1e18 + 1);
         assertEq(shares, 1.25e18);
         assertEq(assets, 1e18);
     }
@@ -125,9 +125,9 @@ contract PSMPreviewWithdraw_SuccessFuzzTests is PSMTestBase {
     }
 
     function testFuzz_previewWithdraw(TestParams memory params) public {
-        params.amount1 = _bound(params.amount1, 1, DAI_TOKEN_MAX);
+        params.amount1 = _bound(params.amount1, 1, USDS_TOKEN_MAX);
         params.amount2 = _bound(params.amount2, 1, USDC_TOKEN_MAX);
-        params.amount3 = _bound(params.amount3, 1, SDAI_TOKEN_MAX);
+        params.amount3 = _bound(params.amount3, 1, SUSDS_TOKEN_MAX);
 
         // Only covering case of amount being below underlying to focus on value conversion
         // and avoid reimplementation of contract logic for dealing with capping amounts
@@ -135,13 +135,13 @@ contract PSMPreviewWithdraw_SuccessFuzzTests is PSMTestBase {
         params.previewAmount2 = _bound(params.previewAmount2, 0, params.amount2);
         params.previewAmount3 = _bound(params.previewAmount3, 0, params.amount3);
 
-        _deposit(address(dai),  address(this), params.amount1);
-        _deposit(address(usdc), address(this), params.amount2);
-        _deposit(address(sDai), address(this), params.amount3);
+        _deposit(address(usds),  address(this), params.amount1);
+        _deposit(address(usdc),  address(this), params.amount2);
+        _deposit(address(susds), address(this), params.amount3);
 
-        ( uint256 shares1, uint256 assets1 ) = psm.previewWithdraw(address(dai),  params.previewAmount1);
-        ( uint256 shares2, uint256 assets2 ) = psm.previewWithdraw(address(usdc), params.previewAmount2);
-        ( uint256 shares3, uint256 assets3 ) = psm.previewWithdraw(address(sDai), params.previewAmount3);
+        ( uint256 shares1, uint256 assets1 ) = psm.previewWithdraw(address(usds),  params.previewAmount1);
+        ( uint256 shares2, uint256 assets2 ) = psm.previewWithdraw(address(usdc),  params.previewAmount2);
+        ( uint256 shares3, uint256 assets3 ) = psm.previewWithdraw(address(susds), params.previewAmount3);
 
         uint256 totalSharesMinted = params.amount1 + params.amount2 * 1e12 + params.amount3 * 1.25e27 / 1e27;
         uint256 totalValue        = totalSharesMinted;
@@ -158,20 +158,20 @@ contract PSMPreviewWithdraw_SuccessFuzzTests is PSMTestBase {
         params.conversionRate = _bound(params.conversionRate, 0.001e27, 1000e27);
         mockRateProvider.__setConversionRate(params.conversionRate);
 
-        // sDai value accrual changes the value of shares in the PSM
+        // susds value accrual changes the value of shares in the PSM
         totalValue = params.amount1 + params.amount2 * 1e12 + params.amount3 * params.conversionRate / 1e27;
 
-        ( shares1, assets1 ) = psm.previewWithdraw(address(dai),  params.previewAmount1);
-        ( shares2, assets2 ) = psm.previewWithdraw(address(usdc), params.previewAmount2);
-        ( shares3, assets3 ) = psm.previewWithdraw(address(sDai), params.previewAmount3);
+        ( shares1, assets1 ) = psm.previewWithdraw(address(usds),  params.previewAmount1);
+        ( shares2, assets2 ) = psm.previewWithdraw(address(usdc),  params.previewAmount2);
+        ( shares3, assets3 ) = psm.previewWithdraw(address(susds), params.previewAmount3);
 
-        uint256 sDaiConvertedAmount = params.previewAmount3 * params.conversionRate / 1e27;
+        uint256 susdsConvertedAmount = params.previewAmount3 * params.conversionRate / 1e27;
 
         // Assert shares are always rounded up, max of 1 wei difference except for sUSDS
         // totalSharesMinted / totalValue is an integer amount that scales as the rate scales by orders of magnitude
         assertLe(shares1 - (params.previewAmount1        * totalSharesMinted / totalValue), 1);
         assertLe(shares2 - (params.previewAmount2 * 1e12 * totalSharesMinted / totalValue), 1);
-        assertLe(shares3 - (sDaiConvertedAmount          * totalSharesMinted / totalValue), 3 + totalSharesMinted / totalValue);
+        assertLe(shares3 - (susdsConvertedAmount         * totalSharesMinted / totalValue), 3 + totalSharesMinted / totalValue);
 
         assertApproxEqAbs(assets1, params.previewAmount1, 1);
         assertApproxEqAbs(assets2, params.previewAmount2, 1);

--- a/test/unit/Rounding.t.sol
+++ b/test/unit/Rounding.t.sol
@@ -15,23 +15,23 @@ contract RoundingTests is PSMTestBase {
         super.setUp();
 
         // Seed the PSM with max liquidity so withdrawals can always be performed
-        _deposit(address(dai),  address(this), DAI_TOKEN_MAX);
-        _deposit(address(sDai), address(this), SDAI_TOKEN_MAX);
-        _deposit(address(usdc), address(this), USDC_TOKEN_MAX);
+        _deposit(address(usds),  address(this), USDS_TOKEN_MAX);
+        _deposit(address(susds), address(this), SUSDS_TOKEN_MAX);
+        _deposit(address(usdc),  address(this), USDC_TOKEN_MAX);
 
         // Set an exchange rate that will cause rounding
         mockRateProvider.__setConversionRate(1.25e27 * uint256(100) / 99);
     }
 
-    function test_roundAgainstUser_dai() public {
-        _deposit(address(dai), address(user), 1e18);
+    function test_roundAgainstUser_usds() public {
+        _deposit(address(usds), address(user), 1e18);
 
-        assertEq(dai.balanceOf(address(user)), 0);
+        assertEq(usds.balanceOf(address(user)), 0);
 
         vm.prank(user);
-        psm.withdraw(address(dai), address(user), 1e18);
+        psm.withdraw(address(usds), address(user), 1e18);
 
-        assertEq(dai.balanceOf(address(user)), 1e18 - 1);  // Rounds against user
+        assertEq(usds.balanceOf(address(user)), 1e18 - 1);  // Rounds against user
     }
 
     function test_roundAgainstUser_usdc() public {
@@ -45,18 +45,18 @@ contract RoundingTests is PSMTestBase {
         assertEq(usdc.balanceOf(address(user)), 1e6 - 1);  // Rounds against user
     }
 
-    function test_roundAgainstUser_sDai() public {
-        _deposit(address(sDai), address(user), 1e18);
+    function test_roundAgainstUser_susds() public {
+        _deposit(address(susds), address(user), 1e18);
 
-        assertEq(sDai.balanceOf(address(user)), 0);
+        assertEq(susds.balanceOf(address(user)), 0);
 
         vm.prank(user);
-        psm.withdraw(address(sDai), address(user), 1e18);
+        psm.withdraw(address(susds), address(user), 1e18);
 
-        assertEq(sDai.balanceOf(address(user)), 1e18 - 1);  // Rounds against user
+        assertEq(susds.balanceOf(address(user)), 1e18 - 1);  // Rounds against user
     }
 
-    function testFuzz_roundingAgainstUser_multiUser_dai(
+    function testFuzz_roundingAgainstUser_multiUser_usds(
         uint256 rate1,
         uint256 rate2,
         uint256 amount1,
@@ -65,8 +65,8 @@ contract RoundingTests is PSMTestBase {
         public
     {
         _runRoundingAgainstUsersFuzzTest(
-            dai,
-            DAI_TOKEN_MAX,
+            usds,
+            USDS_TOKEN_MAX,
             rate1,
             rate2,
             amount1,
@@ -94,7 +94,7 @@ contract RoundingTests is PSMTestBase {
         );
     }
 
-    function testFuzz_roundingAgainstUser_multiUser_sDai(
+    function testFuzz_roundingAgainstUser_multiUser_susds(
         uint256 rate1,
         uint256 rate2,
         uint256 amount1,
@@ -103,13 +103,13 @@ contract RoundingTests is PSMTestBase {
         public
     {
         _runRoundingAgainstUsersFuzzTest(
-            sDai,
-            SDAI_TOKEN_MAX,
+            susds,
+            SUSDS_TOKEN_MAX,
             rate1,
             rate2,
             amount1,
             amount2,
-            4  // sDai has higher rounding errors that can be introduced because of rate conversion
+            4  // susds has higher rounding errors that can be introduced because of rate conversion
         );
     }
 

--- a/test/unit/SetPocket.t.sol
+++ b/test/unit/SetPocket.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import { PSMTestBase } from "test/PSMTestBase.sol";
+
+contract PSMSetPocketFailureTests is PSMTestBase {
+
+    function test_setPocket_invalidOwner() public {
+        vm.expectRevert(
+            abi.encodeWithSignature("OwnableUnauthorizedAccount(address)",
+            address(this))
+        );
+        psm.setPocket(address(1));
+    }
+
+    function test_setPocket_invalidPocket() public {
+        vm.prank(owner);
+        vm.expectRevert("PSM3/invalid-pocket");
+        psm.setPocket(address(0));
+    }
+
+    function test_setPocket_insufficientAllowanceBoundary() public {
+        address pocket1 = makeAddr("pocket1");
+        address pocket2 = makeAddr("pocket2");
+
+        vm.prank(owner);
+        psm.setPocket(pocket1);
+
+        vm.prank(pocket1);
+        usdc.approve(pocket2, 1_000_000e6);
+
+        deal(address(usdc), pocket1, 1_000_000e6 + 1);
+
+        vm.prank(owner);
+        vm.expectRevert("SafeERC20/transfer-from-failed");
+        psm.setPocket(pocket2);
+
+        // deal(address(usdc), pocket1, 1_000_000e6);
+
+        // psm.setPocket(pocket2);
+    }
+
+}

--- a/test/unit/SetPocket.t.sol
+++ b/test/unit/SetPocket.t.sol
@@ -19,6 +19,13 @@ contract PSMSetPocketFailureTests is PSMTestBase {
         psm.setPocket(address(0));
     }
 
+    function test_setPocket_samePocket() public {
+        vm.prank(owner);
+        vm.expectRevert("PSM3/same-pocket");
+        psm.setPocket(address(psm));
+    }
+
+
     // NOTE: In practice this won't happen because pockets will infinite approve PSM
     function test_setPocket_insufficientAllowanceBoundary() public {
         address pocket1 = makeAddr("pocket1");

--- a/test/unit/SetPocket.t.sol
+++ b/test/unit/SetPocket.t.sol
@@ -19,6 +19,7 @@ contract PSMSetPocketFailureTests is PSMTestBase {
         psm.setPocket(address(0));
     }
 
+    // NOTE: In practice this won't happen because pockets will infinite approve PSM
     function test_setPocket_insufficientAllowanceBoundary() public {
         address pocket1 = makeAddr("pocket1");
         address pocket2 = makeAddr("pocket2");
@@ -27,7 +28,7 @@ contract PSMSetPocketFailureTests is PSMTestBase {
         psm.setPocket(pocket1);
 
         vm.prank(pocket1);
-        usdc.approve(pocket2, 1_000_000e6);
+        usdc.approve(address(psm), 1_000_000e6);
 
         deal(address(usdc), pocket1, 1_000_000e6 + 1);
 
@@ -35,9 +36,71 @@ contract PSMSetPocketFailureTests is PSMTestBase {
         vm.expectRevert("SafeERC20/transfer-from-failed");
         psm.setPocket(pocket2);
 
-        // deal(address(usdc), pocket1, 1_000_000e6);
+        deal(address(usdc), pocket1, 1_000_000e6);
 
-        // psm.setPocket(pocket2);
+        vm.prank(owner);
+        psm.setPocket(pocket2);
+    }
+
+}
+
+contract PSMSetPocketSuccessTests is PSMTestBase {
+
+    address pocket1 = makeAddr("pocket1");
+    address pocket2 = makeAddr("pocket2");
+
+    event PocketSet(
+        address indexed oldPocket,
+        address indexed newPocket,
+        uint256 amountTransferred
+    );
+
+    function test_setPocket_pocketIsPsm() public {
+        deal(address(usdc), address(psm), 1_000_000e6);
+
+        assertEq(usdc.balanceOf(address(psm)), 1_000_000e6);
+        assertEq(usdc.balanceOf(pocket1),      0);
+
+        assertEq(psm.pocket(), address(psm));
+
+        vm.prank(owner);
+        vm.expectEmit(address(psm));
+        emit PocketSet(address(psm), pocket1, 1_000_000e6);
+        psm.setPocket(pocket1);
+
+        assertEq(usdc.balanceOf(address(psm)), 0);
+        assertEq(usdc.balanceOf(pocket1),      1_000_000e6);
+
+        assertEq(psm.pocket(), pocket1);
+    }
+
+    function test_setPocket_pocketIsNotPsm() public {
+        vm.prank(owner);
+        psm.setPocket(pocket1);
+
+        vm.prank(pocket1);
+        usdc.approve(address(psm), 1_000_000e6);
+
+        deal(address(usdc), address(pocket1), 1_000_000e6);
+
+        assertEq(usdc.allowance(pocket1, address(psm)), 1_000_000e6);
+
+        assertEq(usdc.balanceOf(pocket1), 1_000_000e6);
+        assertEq(usdc.balanceOf(pocket2), 0);
+
+        assertEq(psm.pocket(), pocket1);
+
+        vm.prank(owner);
+        vm.expectEmit(address(psm));
+        emit PocketSet(pocket1, pocket2, 1_000_000e6);
+        psm.setPocket(pocket2);
+
+        assertEq(usdc.allowance(pocket1, address(psm)), 0);
+
+        assertEq(usdc.balanceOf(pocket1), 0);
+        assertEq(usdc.balanceOf(pocket2), 1_000_000e6);
+
+        assertEq(psm.pocket(), pocket2);
     }
 
 }

--- a/test/unit/SwapExactIn.t.sol
+++ b/test/unit/SwapExactIn.t.sol
@@ -187,13 +187,13 @@ contract PSMSwapExactInSuccessTestsBase is PSMTestBase {
 
 }
 
-contract PSMSwapExactInDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
+contract PSMSwapExactInUsdsAssetInTests is PSMSwapExactInSuccessTestsBase {
 
     function test_swapExactIn_usdsToUsdc_sameReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactInTest(usds, usdc, 100e18, 100e6, swapper, swapper);
     }
 
-    function test_swapExactIn_usdsToSDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactIn_usdsToSUsds_sameReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactInTest(usds, susds, 100e18, 80e18, swapper, swapper);
     }
 
@@ -201,7 +201,7 @@ contract PSMSwapExactInDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
         _swapExactInTest(usds, usdc, 100e18, 100e6, swapper, receiver);
     }
 
-    function test_swapExactIn_usdsToSDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactIn_usdsToSUsds_differentReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactInTest(usds, susds, 100e18, 80e18, swapper, receiver);
     }
 
@@ -219,7 +219,7 @@ contract PSMSwapExactInDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
         _swapExactInTest(usds, usdc, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
     }
 
-    function testFuzz_swapExactIn_usdsToSDai(
+    function testFuzz_swapExactIn_usdsToSUsds(
         uint256 amountIn,
         uint256 conversionRate,
         address fuzzSwapper,
@@ -242,23 +242,23 @@ contract PSMSwapExactInDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
 
 contract PSMSwapExactInUsdcAssetInTests is PSMSwapExactInSuccessTestsBase {
 
-    function test_swapExactIn_usdcToDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactIn_usdcToUsds_sameReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactInTest(usdc, usds, 100e6, 100e18, swapper, swapper);
     }
 
-    function test_swapExactIn_usdcToSDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactIn_usdcToSUsds_sameReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactInTest(usdc, susds, 100e6, 80e18, swapper, swapper);
     }
 
-    function test_swapExactIn_usdcToDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactIn_usdcToUsds_differentReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactInTest(usdc, usds, 100e6, 100e18, swapper, receiver);
     }
 
-    function test_swapExactIn_usdcToSDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactIn_usdcToSUsds_differentReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactInTest(usdc, susds, 100e6, 80e18, swapper, receiver);
     }
 
-    function testFuzz_swapExactIn_usdcToDai(
+    function testFuzz_swapExactIn_usdcToUsds(
         uint256 amountIn,
         address fuzzSwapper,
         address fuzzReceiver
@@ -272,7 +272,7 @@ contract PSMSwapExactInUsdcAssetInTests is PSMSwapExactInSuccessTestsBase {
         _swapExactInTest(usdc, usds, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
     }
 
-    function testFuzz_swapExactIn_usdcToSDai(
+    function testFuzz_swapExactIn_usdcToSUsds(
         uint256 amountIn,
         uint256 conversionRate,
         address fuzzSwapper,
@@ -294,9 +294,9 @@ contract PSMSwapExactInUsdcAssetInTests is PSMSwapExactInSuccessTestsBase {
 
 }
 
-contract PSMSwapExactInSDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
+contract PSMSwapExactInSUsdsAssetInTests is PSMSwapExactInSuccessTestsBase {
 
-    function test_swapExactIn_susdsToDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactIn_susdsToUsds_sameReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactInTest(susds, usds, 100e18, 125e18, swapper, swapper);
     }
 
@@ -304,7 +304,7 @@ contract PSMSwapExactInSDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
         _swapExactInTest(susds, usdc, 100e18, 125e6, swapper, swapper);
     }
 
-    function test_swapExactIn_susdsToDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactIn_susdsToUsds_differentReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactInTest(susds, usds, 100e18, 125e18, swapper, receiver);
     }
 
@@ -312,7 +312,7 @@ contract PSMSwapExactInSDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
         _swapExactInTest(susds, usdc, 100e18, 125e6, swapper, receiver);
     }
 
-    function testFuzz_swapExactIn_susdsToDai(
+    function testFuzz_swapExactIn_susdsToUsds(
         uint256 amountIn,
         uint256 conversionRate,
         address fuzzSwapper,

--- a/test/unit/SwapExactIn.t.sol
+++ b/test/unit/SwapExactIn.t.sol
@@ -17,22 +17,22 @@ contract PSMSwapExactInFailureTests is PSMTestBase {
 
         // Needed for boundary success conditions
         usdc.mint(address(psm), 100e6);
-        sDai.mint(address(psm), 100e18);
+        susds.mint(address(psm), 100e18);
     }
 
     function test_swapExactIn_amountZero() public {
         vm.expectRevert("PSM3/invalid-amountIn");
-        psm.swapExactIn(address(usdc), address(sDai), 0, 0, receiver, 0);
+        psm.swapExactIn(address(usdc), address(susds), 0, 0, receiver, 0);
     }
 
     function test_swapExactIn_receiverZero() public {
         vm.expectRevert("PSM3/invalid-receiver");
-        psm.swapExactIn(address(usdc), address(sDai), 100e6, 80e18, address(0), 0);
+        psm.swapExactIn(address(usdc), address(susds), 100e6, 80e18, address(0), 0);
     }
 
     function test_swapExactIn_invalid_assetIn() public {
         vm.expectRevert("PSM3/invalid-asset");
-        psm.swapExactIn(makeAddr("other-token"), address(sDai), 100e6, 80e18, receiver, 0);
+        psm.swapExactIn(makeAddr("other-token"), address(susds), 100e6, 80e18, receiver, 0);
     }
 
     function test_swapExactIn_invalid_assetOut() public {
@@ -47,12 +47,12 @@ contract PSMSwapExactInFailureTests is PSMTestBase {
 
     function test_swapExactIn_bothUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
-        psm.swapExactIn(address(dai), address(dai), 100e6, 80e18, receiver, 0);
+        psm.swapExactIn(address(usds), address(usds), 100e6, 80e18, receiver, 0);
     }
 
     function test_swapExactIn_bothSUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
-        psm.swapExactIn(address(sDai), address(sDai), 100e6, 80e18, receiver, 0);
+        psm.swapExactIn(address(susds), address(susds), 100e6, 80e18, receiver, 0);
     }
 
     function test_swapExactIn_minAmountOutBoundary() public {
@@ -62,14 +62,14 @@ contract PSMSwapExactInFailureTests is PSMTestBase {
 
         usdc.approve(address(psm), 100e6);
 
-        uint256 expectedAmountOut = psm.previewSwapExactIn(address(usdc), address(sDai), 100e6);
+        uint256 expectedAmountOut = psm.previewSwapExactIn(address(usdc), address(susds), 100e6);
 
         assertEq(expectedAmountOut, 80e18);
 
         vm.expectRevert("PSM3/amountOut-too-low");
-        psm.swapExactIn(address(usdc), address(sDai), 100e6, 80e18 + 1, receiver, 0);
+        psm.swapExactIn(address(usdc), address(susds), 100e6, 80e18 + 1, receiver, 0);
 
-        psm.swapExactIn(address(usdc), address(sDai), 100e6, 80e18, receiver, 0);
+        psm.swapExactIn(address(usdc), address(susds), 100e6, 80e18, receiver, 0);
     }
 
     function test_swapExactIn_insufficientApproveBoundary() public {
@@ -80,11 +80,11 @@ contract PSMSwapExactInFailureTests is PSMTestBase {
         usdc.approve(address(psm), 100e6 - 1);
 
         vm.expectRevert("SafeERC20/transfer-from-failed");
-        psm.swapExactIn(address(usdc), address(sDai), 100e6, 80e18, receiver, 0);
+        psm.swapExactIn(address(usdc), address(susds), 100e6, 80e18, receiver, 0);
 
         usdc.approve(address(psm), 100e6);
 
-        psm.swapExactIn(address(usdc), address(sDai), 100e6, 80e18, receiver, 0);
+        psm.swapExactIn(address(usdc), address(susds), 100e6, 80e18, receiver, 0);
     }
 
     function test_swapExactIn_insufficientUserBalanceBoundary() public {
@@ -95,11 +95,11 @@ contract PSMSwapExactInFailureTests is PSMTestBase {
         usdc.approve(address(psm), 100e6);
 
         vm.expectRevert("SafeERC20/transfer-from-failed");
-        psm.swapExactIn(address(usdc), address(sDai), 100e6, 80e18, receiver, 0);
+        psm.swapExactIn(address(usdc), address(susds), 100e6, 80e18, receiver, 0);
 
         usdc.mint(swapper, 1);
 
-        psm.swapExactIn(address(usdc), address(sDai), 100e6, 80e18, receiver, 0);
+        psm.swapExactIn(address(usdc), address(susds), 100e6, 80e18, receiver, 0);
     }
 
     function test_swapExactIn_insufficientPsmBalanceBoundary() public {
@@ -112,14 +112,14 @@ contract PSMSwapExactInFailureTests is PSMTestBase {
 
         usdc.approve(address(psm), 125e6 + 2);
 
-        uint256 expectedAmountOut = psm.previewSwapExactIn(address(usdc), address(sDai), 125e6 + 2);
+        uint256 expectedAmountOut = psm.previewSwapExactIn(address(usdc), address(susds), 125e6 + 2);
 
-        assertEq(expectedAmountOut, 100.000001e18);  // More than balance of sDAI
+        assertEq(expectedAmountOut, 100.000001e18);  // More than balance of sUSDS
 
         vm.expectRevert("SafeERC20/transfer-failed");
-        psm.swapExactIn(address(usdc), address(sDai), 125e6 + 2, 100e18, receiver, 0);
+        psm.swapExactIn(address(usdc), address(susds), 125e6 + 2, 100e18, receiver, 0);
 
-        psm.swapExactIn(address(usdc), address(sDai), 125e6, 100e18, receiver, 0);
+        psm.swapExactIn(address(usdc), address(susds), 125e6, 100e18, receiver, 0);
     }
 
 }
@@ -134,9 +134,9 @@ contract PSMSwapExactInSuccessTestsBase is PSMTestBase {
 
         // Mint 100x higher than max amount for each token (max conversion rate)
         // Covers both lower and upper bounds of conversion rate (1% to 10,000% are both 100x)
-        dai.mint(address(psm),  DAI_TOKEN_MAX  * 100);
-        usdc.mint(address(psm), USDC_TOKEN_MAX * 100);
-        sDai.mint(address(psm), SDAI_TOKEN_MAX * 100);
+        usds.mint(address(psm),  USDS_TOKEN_MAX  * 100);
+        usdc.mint(address(psm),  USDC_TOKEN_MAX  * 100);
+        susds.mint(address(psm), SUSDS_TOKEN_MAX * 100);
     }
 
     function _swapExactInTest(
@@ -189,23 +189,23 @@ contract PSMSwapExactInSuccessTestsBase is PSMTestBase {
 
 contract PSMSwapExactInDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
 
-    function test_swapExactIn_daiToUsdc_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(dai, usdc, 100e18, 100e6, swapper, swapper);
+    function test_swapExactIn_usdsToUsdc_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactInTest(usds, usdc, 100e18, 100e6, swapper, swapper);
     }
 
-    function test_swapExactIn_daiToSDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(dai, sDai, 100e18, 80e18, swapper, swapper);
+    function test_swapExactIn_usdsToSDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactInTest(usds, susds, 100e18, 80e18, swapper, swapper);
     }
 
-    function test_swapExactIn_daiToUsdc_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(dai, usdc, 100e18, 100e6, swapper, receiver);
+    function test_swapExactIn_usdsToUsdc_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactInTest(usds, usdc, 100e18, 100e6, swapper, receiver);
     }
 
-    function test_swapExactIn_daiToSDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(dai, sDai, 100e18, 80e18, swapper, receiver);
+    function test_swapExactIn_usdsToSDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactInTest(usds, susds, 100e18, 80e18, swapper, receiver);
     }
 
-    function testFuzz_swapExactIn_daiToUsdc(
+    function testFuzz_swapExactIn_usdsToUsdc(
         uint256 amountIn,
         address fuzzSwapper,
         address fuzzReceiver
@@ -214,12 +214,12 @@ contract PSMSwapExactInDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
         vm.assume(fuzzReceiver != address(psm));
         vm.assume(fuzzReceiver != address(0));
 
-        amountIn = _bound(amountIn, 1, DAI_TOKEN_MAX);  // Zero amount reverts
+        amountIn = _bound(amountIn, 1, USDS_TOKEN_MAX);  // Zero amount reverts
         uint256 amountOut = amountIn / 1e12;
-        _swapExactInTest(dai, usdc, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
+        _swapExactInTest(usds, usdc, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
     }
 
-    function testFuzz_swapExactIn_daiToSDai(
+    function testFuzz_swapExactIn_usdsToSDai(
         uint256 amountIn,
         uint256 conversionRate,
         address fuzzSwapper,
@@ -229,13 +229,13 @@ contract PSMSwapExactInDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
         vm.assume(fuzzReceiver != address(psm));
         vm.assume(fuzzReceiver != address(0));
 
-        amountIn       = _bound(amountIn,       1,       DAI_TOKEN_MAX);
+        amountIn       = _bound(amountIn,       1,       USDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.01e27, 100e27);  // 1% to 10,000% conversion rate
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 amountOut = amountIn * 1e27 / conversionRate;
 
-        _swapExactInTest(dai, sDai, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
+        _swapExactInTest(usds, susds, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
     }
 
 }
@@ -243,19 +243,19 @@ contract PSMSwapExactInDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
 contract PSMSwapExactInUsdcAssetInTests is PSMSwapExactInSuccessTestsBase {
 
     function test_swapExactIn_usdcToDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(usdc, dai, 100e6, 100e18, swapper, swapper);
+        _swapExactInTest(usdc, usds, 100e6, 100e18, swapper, swapper);
     }
 
     function test_swapExactIn_usdcToSDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(usdc, sDai, 100e6, 80e18, swapper, swapper);
+        _swapExactInTest(usdc, susds, 100e6, 80e18, swapper, swapper);
     }
 
     function test_swapExactIn_usdcToDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(usdc, dai, 100e6, 100e18, swapper, receiver);
+        _swapExactInTest(usdc, usds, 100e6, 100e18, swapper, receiver);
     }
 
     function test_swapExactIn_usdcToSDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(usdc, sDai, 100e6, 80e18, swapper, receiver);
+        _swapExactInTest(usdc, susds, 100e6, 80e18, swapper, receiver);
     }
 
     function testFuzz_swapExactIn_usdcToDai(
@@ -269,7 +269,7 @@ contract PSMSwapExactInUsdcAssetInTests is PSMSwapExactInSuccessTestsBase {
 
         amountIn = _bound(amountIn, 1, USDC_TOKEN_MAX);  // Zero amount reverts
         uint256 amountOut = amountIn * 1e12;
-        _swapExactInTest(usdc, dai, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
+        _swapExactInTest(usdc, usds, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
     }
 
     function testFuzz_swapExactIn_usdcToSDai(
@@ -289,30 +289,30 @@ contract PSMSwapExactInUsdcAssetInTests is PSMSwapExactInSuccessTestsBase {
 
         uint256 amountOut = amountIn * 1e27 / conversionRate * 1e12;
 
-        _swapExactInTest(usdc, sDai, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
+        _swapExactInTest(usdc, susds, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
     }
 
 }
 
 contract PSMSwapExactInSDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
 
-    function test_swapExactIn_sDaiToDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(sDai, dai, 100e18, 125e18, swapper, swapper);
+    function test_swapExactIn_susdsToDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactInTest(susds, usds, 100e18, 125e18, swapper, swapper);
     }
 
-    function test_swapExactIn_sDaiToUsdc_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(sDai, usdc, 100e18, 125e6, swapper, swapper);
+    function test_swapExactIn_susdsToUsdc_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactInTest(susds, usdc, 100e18, 125e6, swapper, swapper);
     }
 
-    function test_swapExactIn_sDaiToDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(sDai, dai, 100e18, 125e18, swapper, receiver);
+    function test_swapExactIn_susdsToDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactInTest(susds, usds, 100e18, 125e18, swapper, receiver);
     }
 
-    function test_swapExactIn_sDaiToUsdc_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactInTest(sDai, usdc, 100e18, 125e6, swapper, receiver);
+    function test_swapExactIn_susdsToUsdc_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactInTest(susds, usdc, 100e18, 125e6, swapper, receiver);
     }
 
-    function testFuzz_swapExactIn_sDaiToDai(
+    function testFuzz_swapExactIn_susdsToDai(
         uint256 amountIn,
         uint256 conversionRate,
         address fuzzSwapper,
@@ -322,17 +322,17 @@ contract PSMSwapExactInSDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
         vm.assume(fuzzReceiver != address(psm));
         vm.assume(fuzzReceiver != address(0));
 
-        amountIn       = _bound(amountIn,       1,       SDAI_TOKEN_MAX);
+        amountIn       = _bound(amountIn,       1,       SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.01e27, 100e27);  // 1% to 10,000% conversion rate
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 amountOut = amountIn * conversionRate / 1e27;
 
-        _swapExactInTest(sDai, dai, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
+        _swapExactInTest(susds, usds, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
     }
 
-    function testFuzz_swapExactIn_sDaiToUsdc(
+    function testFuzz_swapExactIn_susdsToUsdc(
         uint256 amountIn,
         uint256 conversionRate,
         address fuzzSwapper,
@@ -342,14 +342,14 @@ contract PSMSwapExactInSDaiAssetInTests is PSMSwapExactInSuccessTestsBase {
         vm.assume(fuzzReceiver != address(psm));
         vm.assume(fuzzReceiver != address(0));
 
-        amountIn       = _bound(amountIn,       1,       SDAI_TOKEN_MAX);
+        amountIn       = _bound(amountIn,       1,       SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.01e27, 100e27);  // 1% to 10,000% conversion rate
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 amountOut = amountIn * conversionRate / 1e27 / 1e12;
 
-        _swapExactInTest(sDai, usdc, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
+        _swapExactInTest(susds, usdc, amountIn, amountOut, fuzzSwapper, fuzzReceiver);
     }
 
 }
@@ -383,14 +383,14 @@ contract PSMSwapExactInFuzzTests is PSMTestBase {
         // 1% to 200% conversion rate
         mockRateProvider.__setConversionRate(_bound(conversionRate, 0.01e27, 2e27));
 
-        _deposit(address(dai), lp0, _bound(_hash(depositSeed, "lp0-dai"), 1, DAI_TOKEN_MAX));
+        _deposit(address(usds), lp0, _bound(_hash(depositSeed, "lp0-usds"), 1, USDS_TOKEN_MAX));
 
-        _deposit(address(usdc), lp1, _bound(_hash(depositSeed, "lp1-usdc"), 1, USDC_TOKEN_MAX));
-        _deposit(address(sDai), lp1, _bound(_hash(depositSeed, "lp1-sdai"), 1, SDAI_TOKEN_MAX));
+        _deposit(address(usdc),  lp1, _bound(_hash(depositSeed, "lp1-usdc"),  1, USDC_TOKEN_MAX));
+        _deposit(address(susds), lp1, _bound(_hash(depositSeed, "lp1-susds"), 1, SUSDS_TOKEN_MAX));
 
-        _deposit(address(dai),  lp2, _bound(_hash(depositSeed, "lp2-dai"),  1, DAI_TOKEN_MAX));
-        _deposit(address(usdc), lp2, _bound(_hash(depositSeed, "lp2-usdc"), 1, USDC_TOKEN_MAX));
-        _deposit(address(sDai), lp2, _bound(_hash(depositSeed, "lp2-sdai"), 1, SDAI_TOKEN_MAX));
+        _deposit(address(usds),  lp2, _bound(_hash(depositSeed, "lp2-usds"),  1, USDS_TOKEN_MAX));
+        _deposit(address(usdc),  lp2, _bound(_hash(depositSeed, "lp2-usdc"),  1, USDC_TOKEN_MAX));
+        _deposit(address(susds), lp2, _bound(_hash(depositSeed, "lp2-susds"), 1, SUSDS_TOKEN_MAX));
 
         FuzzVars memory vars;
 
@@ -460,9 +460,9 @@ contract PSMSwapExactInFuzzTests is PSMTestBase {
     function _getAsset(uint256 indexSeed) internal view returns (MockERC20) {
         uint256 index = indexSeed % 3;
 
-        if (index == 0) return dai;
+        if (index == 0) return usds;
         if (index == 1) return usdc;
-        if (index == 2) return sDai;
+        if (index == 2) return susds;
 
         else revert("Invalid index");
     }

--- a/test/unit/SwapExactIn.t.sol
+++ b/test/unit/SwapExactIn.t.sol
@@ -40,17 +40,17 @@ contract PSMSwapExactInFailureTests is PSMTestBase {
         psm.swapExactIn(address(usdc), makeAddr("other-token"), 100e6, 80e18, receiver, 0);
     }
 
-    function test_swapExactIn_bothAsset0() public {
-        vm.expectRevert("PSM3/invalid-asset");
-        psm.swapExactIn(address(dai), address(dai), 100e6, 80e18, receiver, 0);
-    }
-
-    function test_swapExactIn_bothAsset1() public {
+    function test_swapExactIn_bothUsdc() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.swapExactIn(address(usdc), address(usdc), 100e6, 80e18, receiver, 0);
     }
 
-    function test_swapExactIn_bothAsset2() public {
+    function test_swapExactIn_bothUsds() public {
+        vm.expectRevert("PSM3/invalid-asset");
+        psm.swapExactIn(address(dai), address(dai), 100e6, 80e18, receiver, 0);
+    }
+
+    function test_swapExactIn_bothSUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.swapExactIn(address(sDai), address(sDai), 100e6, 80e18, receiver, 0);
     }

--- a/test/unit/SwapExactOut.t.sol
+++ b/test/unit/SwapExactOut.t.sol
@@ -40,17 +40,17 @@ contract PSMSwapExactOutFailureTests is PSMTestBase {
         psm.swapExactOut(address(usdc), makeAddr("other-token"), 100e6, 80e18, receiver, 0);
     }
 
-    function test_swapExactOut_bothAsset0() public {
-        vm.expectRevert("PSM3/invalid-asset");
-        psm.swapExactOut(address(dai), address(dai), 100e6, 80e18, receiver, 0);
-    }
-
-    function test_swapExactOut_bothAsset1() public {
+    function test_swapExactOut_bothUsdc() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.swapExactOut(address(usdc), address(usdc), 100e6, 80e18, receiver, 0);
     }
 
-    function test_swapExactOut_bothAsset2() public {
+    function test_swapExactOut_bothUsds() public {
+        vm.expectRevert("PSM3/invalid-asset");
+        psm.swapExactOut(address(dai), address(dai), 100e6, 80e18, receiver, 0);
+    }
+
+    function test_swapExactOut_bothSUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.swapExactOut(address(sDai), address(sDai), 100e6, 80e18, receiver, 0);
     }

--- a/test/unit/SwapExactOut.t.sol
+++ b/test/unit/SwapExactOut.t.sol
@@ -17,22 +17,22 @@ contract PSMSwapExactOutFailureTests is PSMTestBase {
 
         // Needed for boundary success conditions
         usdc.mint(address(psm), 100e6);
-        sDai.mint(address(psm), 100e18);
+        susds.mint(address(psm), 100e18);
     }
 
     function test_swapExactOut_amountZero() public {
         vm.expectRevert("PSM3/invalid-amountOut");
-        psm.swapExactOut(address(usdc), address(sDai), 0, 0, receiver, 0);
+        psm.swapExactOut(address(usdc), address(susds), 0, 0, receiver, 0);
     }
 
     function test_swapExactOut_receiverZero() public {
         vm.expectRevert("PSM3/invalid-receiver");
-        psm.swapExactOut(address(usdc), address(sDai), 100e6, 80e18, address(0), 0);
+        psm.swapExactOut(address(usdc), address(susds), 100e6, 80e18, address(0), 0);
     }
 
     function test_swapExactOut_invalid_assetIn() public {
         vm.expectRevert("PSM3/invalid-asset");
-        psm.swapExactOut(makeAddr("other-token"), address(sDai), 100e6, 80e18, receiver, 0);
+        psm.swapExactOut(makeAddr("other-token"), address(susds), 100e6, 80e18, receiver, 0);
     }
 
     function test_swapExactOut_invalid_assetOut() public {
@@ -47,12 +47,12 @@ contract PSMSwapExactOutFailureTests is PSMTestBase {
 
     function test_swapExactOut_bothUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
-        psm.swapExactOut(address(dai), address(dai), 100e6, 80e18, receiver, 0);
+        psm.swapExactOut(address(usds), address(usds), 100e6, 80e18, receiver, 0);
     }
 
     function test_swapExactOut_bothSUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
-        psm.swapExactOut(address(sDai), address(sDai), 100e6, 80e18, receiver, 0);
+        psm.swapExactOut(address(susds), address(susds), 100e6, 80e18, receiver, 0);
     }
 
     function test_swapExactOut_maxAmountBoundary() public {
@@ -62,14 +62,14 @@ contract PSMSwapExactOutFailureTests is PSMTestBase {
 
         usdc.approve(address(psm), 100e6);
 
-        uint256 expectedAmountIn = psm.previewSwapExactOut(address(usdc), address(sDai), 80e18);
+        uint256 expectedAmountIn = psm.previewSwapExactOut(address(usdc), address(susds), 80e18);
 
         assertEq(expectedAmountIn, 100e6);
 
         vm.expectRevert("PSM3/amountIn-too-high");
-        psm.swapExactOut(address(usdc), address(sDai), 80e18, 100e6 - 1, receiver, 0);
+        psm.swapExactOut(address(usdc), address(susds), 80e18, 100e6 - 1, receiver, 0);
 
-        psm.swapExactOut(address(usdc), address(sDai), 80e18, 100e6, receiver, 0);
+        psm.swapExactOut(address(usdc), address(susds), 80e18, 100e6, receiver, 0);
     }
 
     function test_swapExactOut_insufficientApproveBoundary() public {
@@ -80,11 +80,11 @@ contract PSMSwapExactOutFailureTests is PSMTestBase {
         usdc.approve(address(psm), 100e6 - 1);
 
         vm.expectRevert("SafeERC20/transfer-from-failed");
-        psm.swapExactOut(address(usdc), address(sDai), 80e18, 100e6, receiver, 0);
+        psm.swapExactOut(address(usdc), address(susds), 80e18, 100e6, receiver, 0);
 
         usdc.approve(address(psm), 100e6);
 
-        psm.swapExactOut(address(usdc), address(sDai), 80e18, 100e6, receiver, 0);
+        psm.swapExactOut(address(usdc), address(susds), 80e18, 100e6, receiver, 0);
     }
 
     function test_swapExactOut_insufficientUserBalanceBoundary() public {
@@ -95,11 +95,11 @@ contract PSMSwapExactOutFailureTests is PSMTestBase {
         usdc.approve(address(psm), 100e6);
 
         vm.expectRevert("SafeERC20/transfer-from-failed");
-        psm.swapExactOut(address(usdc), address(sDai), 80e18, 100e6, receiver, 0);
+        psm.swapExactOut(address(usdc), address(susds), 80e18, 100e6, receiver, 0);
 
         usdc.mint(swapper, 1);
 
-        psm.swapExactOut(address(usdc), address(sDai), 80e18, 100e6, receiver, 0);
+        psm.swapExactOut(address(usdc), address(susds), 80e18, 100e6, receiver, 0);
     }
 
     function test_swapExactOut_insufficientPsmBalanceBoundary() public {
@@ -111,9 +111,9 @@ contract PSMSwapExactOutFailureTests is PSMTestBase {
         usdc.approve(address(psm), 125e6 + 1);
 
         vm.expectRevert("SafeERC20/transfer-failed");
-        psm.swapExactOut(address(usdc), address(sDai), 100e18 + 1, 125e6 + 1, receiver, 0);
+        psm.swapExactOut(address(usdc), address(susds), 100e18 + 1, 125e6 + 1, receiver, 0);
 
-        psm.swapExactOut(address(usdc), address(sDai), 100e18, 125e6 + 1, receiver, 0);
+        psm.swapExactOut(address(usdc), address(susds), 100e18, 125e6 + 1, receiver, 0);
     }
 
 }
@@ -128,9 +128,9 @@ contract PSMSwapExactOutSuccessTestsBase is PSMTestBase {
 
         // Mint 100x higher than max amount for each token (max conversion rate)
         // Covers both lower and upper bounds of conversion rate (1% to 10,000% are both 100x)
-        dai.mint(address(psm),  DAI_TOKEN_MAX  * 100);
-        usdc.mint(address(psm), USDC_TOKEN_MAX * 100);
-        sDai.mint(address(psm), SDAI_TOKEN_MAX * 100);
+        usds.mint(address(psm),  USDS_TOKEN_MAX  * 100);
+        usdc.mint(address(psm),  USDC_TOKEN_MAX  * 100);
+        susds.mint(address(psm), SUSDS_TOKEN_MAX * 100);
     }
 
     function _swapExactOutTest(
@@ -183,23 +183,23 @@ contract PSMSwapExactOutSuccessTestsBase is PSMTestBase {
 
 contract PSMSwapExactOutDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
 
-    function test_swapExactOut_daiToUsdc_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(dai, usdc, 100e6, 100e18, swapper, swapper);
+    function test_swapExactOut_usdsToUsdc_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactOutTest(usds, usdc, 100e6, 100e18, swapper, swapper);
     }
 
-    function test_swapExactOut_daiToSDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(dai, sDai, 80e18, 100e18, swapper, swapper);
+    function test_swapExactOut_usdsToSDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactOutTest(usds, susds, 80e18, 100e18, swapper, swapper);
     }
 
-    function test_swapExactOut_daiToUsdc_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(dai, usdc, 100e6, 100e18, swapper, receiver);
+    function test_swapExactOut_usdsToUsdc_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactOutTest(usds, usdc, 100e6, 100e18, swapper, receiver);
     }
 
-    function test_swapExactOut_daiToSDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(dai, sDai, 80e18, 100e18, swapper, receiver);
+    function test_swapExactOut_usdsToSDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactOutTest(usds, susds, 80e18, 100e18, swapper, receiver);
     }
 
-    function testFuzz_swapExactOut_daiToUsdc(
+    function testFuzz_swapExactOut_usdsToUsdc(
         uint256 amountOut,
         address fuzzSwapper,
         address fuzzReceiver
@@ -210,10 +210,10 @@ contract PSMSwapExactOutDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
 
         amountOut = _bound(amountOut, 1, USDC_TOKEN_MAX);  // Zero amount reverts
         uint256 amountIn = amountOut * 1e12;
-        _swapExactOutTest(dai, usdc, amountOut, amountIn, fuzzSwapper, fuzzReceiver);
+        _swapExactOutTest(usds, usdc, amountOut, amountIn, fuzzSwapper, fuzzReceiver);
     }
 
-    function testFuzz_swapExactOut_daiToSDai(
+    function testFuzz_swapExactOut_usdsToSDai(
         uint256 amountOut,
         uint256 conversionRate,
         address fuzzSwapper,
@@ -223,19 +223,19 @@ contract PSMSwapExactOutDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
         vm.assume(fuzzReceiver != address(psm));
         vm.assume(fuzzReceiver != address(0));
 
-        amountOut      = _bound(amountOut,      1,       DAI_TOKEN_MAX);
+        amountOut      = _bound(amountOut,      1,       USDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.01e27, 100e27);  // 1% to 10,000% conversion rate
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 amountIn = amountOut * conversionRate / 1e27;
 
-        uint256 returnedAmountIn = psm.previewSwapExactOut(address(dai), address(sDai), amountOut);
+        uint256 returnedAmountIn = psm.previewSwapExactOut(address(usds), address(susds), amountOut);
 
         // Assert that returnedAmount is within 1 of the expected amount and rounding up
         // Use returnedAmountIn in helper function so all values are exact
         assertLe(returnedAmountIn - amountIn, 1);
 
-        _swapExactOutTest(dai, sDai, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
+        _swapExactOutTest(usds, susds, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
     }
 
 }
@@ -243,19 +243,19 @@ contract PSMSwapExactOutDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
 contract PSMSwapExactOutUsdcAssetInTests is PSMSwapExactOutSuccessTestsBase {
 
     function test_swapExactOut_usdcToDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(usdc, dai, 100e18, 100e6, swapper, swapper);
+        _swapExactOutTest(usdc, usds, 100e18, 100e6, swapper, swapper);
     }
 
     function test_swapExactOut_usdcToSDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(usdc, sDai, 80e18, 100e6, swapper, swapper);
+        _swapExactOutTest(usdc, susds, 80e18, 100e6, swapper, swapper);
     }
 
     function test_swapExactOut_usdcToDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(usdc, dai, 100e18, 100e6, swapper, receiver);
+        _swapExactOutTest(usdc, usds, 100e18, 100e6, swapper, receiver);
     }
 
     function test_swapExactOut_usdcToSDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(usdc, sDai, 80e18, 100e6, swapper, receiver);
+        _swapExactOutTest(usdc, susds, 80e18, 100e6, swapper, receiver);
     }
 
     function testFuzz_swapExactOut_usdcToDai(
@@ -267,16 +267,16 @@ contract PSMSwapExactOutUsdcAssetInTests is PSMSwapExactOutSuccessTestsBase {
         vm.assume(fuzzReceiver != address(psm));
         vm.assume(fuzzReceiver != address(0));
 
-        amountOut = _bound(amountOut, 1, DAI_TOKEN_MAX);  // Zero amount reverts
+        amountOut = _bound(amountOut, 1, USDS_TOKEN_MAX);  // Zero amount reverts
         uint256 amountIn = amountOut / 1e12;
 
-        uint256 returnedAmountIn = psm.previewSwapExactOut(address(usdc), address(dai), amountOut);
+        uint256 returnedAmountIn = psm.previewSwapExactOut(address(usdc), address(usds), amountOut);
 
         // Assert that returnedAmount is within 1 of the expected amount and rounding up
         // Use returnedAmountIn in helper function so all values are exact
         assertLe(returnedAmountIn - amountIn, 1);
 
-        _swapExactOutTest(usdc, dai, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
+        _swapExactOutTest(usdc, usds, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
     }
 
     function testFuzz_swapExactOut_usdcToSDai(
@@ -289,43 +289,43 @@ contract PSMSwapExactOutUsdcAssetInTests is PSMSwapExactOutSuccessTestsBase {
         vm.assume(fuzzReceiver != address(psm));
         vm.assume(fuzzReceiver != address(0));
 
-        amountOut      = _bound(amountOut,      1,       SDAI_TOKEN_MAX);
+        amountOut      = _bound(amountOut,      1,       SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.01e27, 100e27);  // 1% to 10,000% conversion rate
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 amountIn = amountOut * conversionRate / 1e27 / 1e12;
 
-        uint256 returnedAmountIn = psm.previewSwapExactOut(address(usdc), address(sDai), amountOut);
+        uint256 returnedAmountIn = psm.previewSwapExactOut(address(usdc), address(susds), amountOut);
 
         // Assert that returnedAmount is within 1 of the expected amount and rounding up
         // Use returnedAmountIn in helper function so all values are exact
         assertLe(returnedAmountIn - amountIn, 1);
 
-        _swapExactOutTest(usdc, sDai, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
+        _swapExactOutTest(usdc, susds, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
     }
 
 }
 
 contract PSMSwapExactOutSDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
 
-    function test_swapExactOut_sDaiToDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(sDai, dai, 125e18, 100e18, swapper, swapper);
+    function test_swapExactOut_susdsToDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactOutTest(susds, usds, 125e18, 100e18, swapper, swapper);
     }
 
-    function test_swapExactOut_sDaiToUsdc_sameReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(sDai, usdc, 125e6, 100e18, swapper, swapper);
+    function test_swapExactOut_susdsToUsdc_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactOutTest(susds, usdc, 125e6, 100e18, swapper, swapper);
     }
 
-    function test_swapExactOut_sDaiToDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(sDai, dai, 125e18, 100e18, swapper, receiver);
+    function test_swapExactOut_susdsToDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactOutTest(susds, usds, 125e18, 100e18, swapper, receiver);
     }
 
-    function test_swapExactOut_sDaiToUsdc_differentReceiver() public assertAtomicPsmValueDoesNotChange {
-        _swapExactOutTest(sDai, usdc, 125e6, 100e18, swapper, receiver);
+    function test_swapExactOut_susdsToUsdc_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+        _swapExactOutTest(susds, usdc, 125e6, 100e18, swapper, receiver);
     }
 
-    function testFuzz_swapExactOut_sDaiToDai(
+    function testFuzz_swapExactOut_susdsToDai(
         uint256 amountOut,
         uint256 conversionRate,
         address fuzzSwapper,
@@ -335,23 +335,23 @@ contract PSMSwapExactOutSDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
         vm.assume(fuzzReceiver != address(psm));
         vm.assume(fuzzReceiver != address(0));
 
-        amountOut      = _bound(amountOut,      1,       DAI_TOKEN_MAX);
+        amountOut      = _bound(amountOut,      1,       USDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.01e27, 100e27);  // 1% to 10,000% conversion rate
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 amountIn = amountOut * 1e27 / conversionRate;
 
-        uint256 returnedAmountIn = psm.previewSwapExactOut(address(sDai), address(dai), amountOut);
+        uint256 returnedAmountIn = psm.previewSwapExactOut(address(susds), address(usds), amountOut);
 
         // Assert that returnedAmount is within 1 of the expected amount and rounding up
         // Use returnedAmountIn in helper function so all values are exact
         assertLe(returnedAmountIn - amountIn, 1);
 
-        _swapExactOutTest(sDai, dai, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
+        _swapExactOutTest(susds, usds, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
     }
 
-    function testFuzz_swapExactOut_sDaiToUsdc(
+    function testFuzz_swapExactOut_susdsToUsdc(
         uint256 amountOut,
         uint256 conversionRate,
         address fuzzSwapper,
@@ -368,14 +368,14 @@ contract PSMSwapExactOutSDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
 
         uint256 amountIn = amountOut * 1e27 / conversionRate * 1e12;
 
-        uint256 returnedAmountIn = psm.previewSwapExactOut(address(sDai), address(usdc), amountOut);
+        uint256 returnedAmountIn = psm.previewSwapExactOut(address(susds), address(usdc), amountOut);
 
         // Assert that returnedAmount is within 1 of the expected amount and rounding up
         // Use returnedAmountIn in helper function so all asserted values are exact
         // Rounding can cause returnedAmountIn to be up to 1e12 higher than naive calculation
         assertLe(returnedAmountIn - amountIn, 1e12);
 
-        _swapExactOutTest(sDai, usdc, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
+        _swapExactOutTest(susds, usdc, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
     }
 
 }
@@ -409,14 +409,14 @@ contract PSMSwapExactOutFuzzTests is PSMTestBase {
         // 1% to 200% conversion rate
         mockRateProvider.__setConversionRate(_bound(conversionRate, 0.01e27, 2e27));
 
-        _deposit(address(dai), lp0, _bound(_hash(depositSeed, "lp0-dai"), 1, DAI_TOKEN_MAX));
+        _deposit(address(usds), lp0, _bound(_hash(depositSeed, "lp0-usds"), 1, USDS_TOKEN_MAX));
 
-        _deposit(address(usdc), lp1, _bound(_hash(depositSeed, "lp1-usdc"), 1, USDC_TOKEN_MAX));
-        _deposit(address(sDai), lp1, _bound(_hash(depositSeed, "lp1-sdai"), 1, SDAI_TOKEN_MAX));
+        _deposit(address(usdc),  lp1, _bound(_hash(depositSeed, "lp1-usdc"),  1, USDC_TOKEN_MAX));
+        _deposit(address(susds), lp1, _bound(_hash(depositSeed, "lp1-susds"), 1, SUSDS_TOKEN_MAX));
 
-        _deposit(address(dai),  lp2, _bound(_hash(depositSeed, "lp2-dai"),  1, DAI_TOKEN_MAX));
-        _deposit(address(usdc), lp2, _bound(_hash(depositSeed, "lp2-usdc"), 1, USDC_TOKEN_MAX));
-        _deposit(address(sDai), lp2, _bound(_hash(depositSeed, "lp2-sdai"), 1, SDAI_TOKEN_MAX));
+        _deposit(address(usds),  lp2, _bound(_hash(depositSeed, "lp2-usds"),  1, USDS_TOKEN_MAX));
+        _deposit(address(usdc),  lp2, _bound(_hash(depositSeed, "lp2-usdc"),  1, USDC_TOKEN_MAX));
+        _deposit(address(susds), lp2, _bound(_hash(depositSeed, "lp2-susds"), 1, SUSDS_TOKEN_MAX));
 
         FuzzVars memory vars;
 
@@ -482,9 +482,9 @@ contract PSMSwapExactOutFuzzTests is PSMTestBase {
     function _getAsset(uint256 indexSeed) internal view returns (MockERC20) {
         uint256 index = indexSeed % 3;
 
-        if (index == 0) return dai;
+        if (index == 0) return usds;
         if (index == 1) return usdc;
-        if (index == 2) return sDai;
+        if (index == 2) return susds;
 
         else revert("Invalid index");
     }

--- a/test/unit/SwapExactOut.t.sol
+++ b/test/unit/SwapExactOut.t.sol
@@ -181,13 +181,13 @@ contract PSMSwapExactOutSuccessTestsBase is PSMTestBase {
 
 }
 
-contract PSMSwapExactOutDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
+contract PSMSwapExactOutUsdsAssetInTests is PSMSwapExactOutSuccessTestsBase {
 
     function test_swapExactOut_usdsToUsdc_sameReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactOutTest(usds, usdc, 100e6, 100e18, swapper, swapper);
     }
 
-    function test_swapExactOut_usdsToSDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactOut_usdsToSUsds_sameReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactOutTest(usds, susds, 80e18, 100e18, swapper, swapper);
     }
 
@@ -195,7 +195,7 @@ contract PSMSwapExactOutDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
         _swapExactOutTest(usds, usdc, 100e6, 100e18, swapper, receiver);
     }
 
-    function test_swapExactOut_usdsToSDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactOut_usdsToSUsds_differentReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactOutTest(usds, susds, 80e18, 100e18, swapper, receiver);
     }
 
@@ -213,7 +213,7 @@ contract PSMSwapExactOutDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
         _swapExactOutTest(usds, usdc, amountOut, amountIn, fuzzSwapper, fuzzReceiver);
     }
 
-    function testFuzz_swapExactOut_usdsToSDai(
+    function testFuzz_swapExactOut_usdsToSUsds(
         uint256 amountOut,
         uint256 conversionRate,
         address fuzzSwapper,
@@ -242,23 +242,23 @@ contract PSMSwapExactOutDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
 
 contract PSMSwapExactOutUsdcAssetInTests is PSMSwapExactOutSuccessTestsBase {
 
-    function test_swapExactOut_usdcToDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactOut_usdcToUsds_sameReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactOutTest(usdc, usds, 100e18, 100e6, swapper, swapper);
     }
 
-    function test_swapExactOut_usdcToSDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactOut_usdcToSUsds_sameReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactOutTest(usdc, susds, 80e18, 100e6, swapper, swapper);
     }
 
-    function test_swapExactOut_usdcToDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactOut_usdcToUsds_differentReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactOutTest(usdc, usds, 100e18, 100e6, swapper, receiver);
     }
 
-    function test_swapExactOut_usdcToSDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactOut_usdcToSUsds_differentReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactOutTest(usdc, susds, 80e18, 100e6, swapper, receiver);
     }
 
-    function testFuzz_swapExactOut_usdcToDai(
+    function testFuzz_swapExactOut_usdcToUsds(
         uint256 amountOut,
         address fuzzSwapper,
         address fuzzReceiver
@@ -279,7 +279,7 @@ contract PSMSwapExactOutUsdcAssetInTests is PSMSwapExactOutSuccessTestsBase {
         _swapExactOutTest(usdc, usds, amountOut, returnedAmountIn, fuzzSwapper, fuzzReceiver);
     }
 
-    function testFuzz_swapExactOut_usdcToSDai(
+    function testFuzz_swapExactOut_usdcToSUsds(
         uint256 amountOut,
         uint256 conversionRate,
         address fuzzSwapper,
@@ -307,9 +307,9 @@ contract PSMSwapExactOutUsdcAssetInTests is PSMSwapExactOutSuccessTestsBase {
 
 }
 
-contract PSMSwapExactOutSDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
+contract PSMSwapExactOutSUsdsAssetInTests is PSMSwapExactOutSuccessTestsBase {
 
-    function test_swapExactOut_susdsToDai_sameReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactOut_susdsToUsds_sameReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactOutTest(susds, usds, 125e18, 100e18, swapper, swapper);
     }
 
@@ -317,7 +317,7 @@ contract PSMSwapExactOutSDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
         _swapExactOutTest(susds, usdc, 125e6, 100e18, swapper, swapper);
     }
 
-    function test_swapExactOut_susdsToDai_differentReceiver() public assertAtomicPsmValueDoesNotChange {
+    function test_swapExactOut_susdsToUsds_differentReceiver() public assertAtomicPsmValueDoesNotChange {
         _swapExactOutTest(susds, usds, 125e18, 100e18, swapper, receiver);
     }
 
@@ -325,7 +325,7 @@ contract PSMSwapExactOutSDaiAssetInTests is PSMSwapExactOutSuccessTestsBase {
         _swapExactOutTest(susds, usdc, 125e6, 100e18, swapper, receiver);
     }
 
-    function testFuzz_swapExactOut_susdsToDai(
+    function testFuzz_swapExactOut_susdsToUsds(
         uint256 amountOut,
         uint256 conversionRate,
         address fuzzSwapper,

--- a/test/unit/SwapPreviews.t.sol
+++ b/test/unit/SwapPreviews.t.sol
@@ -24,12 +24,12 @@ contract PSMPreviewSwapExactIn_FailureTests is PSMTestBase {
 
     function test_previewSwapExactIn_bothUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
-        psm.previewSwapExactIn(address(dai), address(dai), 1);
+        psm.previewSwapExactIn(address(usds), address(usds), 1);
     }
 
     function test_previewSwapExactIn_bothSUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
-        psm.previewSwapExactIn(address(sDai), address(sDai), 1);
+        psm.previewSwapExactIn(address(susds), address(susds), 1);
     }
 
 }
@@ -48,7 +48,7 @@ contract PSMPreviewSwapExactOut_FailureTests is PSMTestBase {
 
     function test_previewSwapExactOut_bothUsdc() public {
         vm.expectRevert("PSM3/invalid-asset");
-        psm.previewSwapExactOut(address(dai), address(dai), 1);
+        psm.previewSwapExactOut(address(usds), address(usds), 1);
     }
 
     function test_previewSwapExactOut_bothUsds() public {
@@ -58,88 +58,88 @@ contract PSMPreviewSwapExactOut_FailureTests is PSMTestBase {
 
     function test_previewSwapExactOut_bothSUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
-        psm.previewSwapExactOut(address(sDai), address(sDai), 1);
+        psm.previewSwapExactOut(address(susds), address(susds), 1);
     }
 
 }
 
 contract PSMPreviewSwapExactIn_DaiAssetInTests is PSMTestBase {
 
-    function test_previewSwapExactIn_daiToUsdc() public view {
+    function test_previewSwapExactIn_usdsToUsdc() public view {
         // Demo rounding down
-        assertEq(psm.previewSwapExactIn(address(dai), address(usdc), 1e18 - 1), 1e6 - 1);
-        assertEq(psm.previewSwapExactIn(address(dai), address(usdc), 1e18),     1e6);
-        assertEq(psm.previewSwapExactIn(address(dai), address(usdc), 1e18 + 1), 1e6);
+        assertEq(psm.previewSwapExactIn(address(usds), address(usdc), 1e18 - 1), 1e6 - 1);
+        assertEq(psm.previewSwapExactIn(address(usds), address(usdc), 1e18),     1e6);
+        assertEq(psm.previewSwapExactIn(address(usds), address(usdc), 1e18 + 1), 1e6);
 
-        assertEq(psm.previewSwapExactIn(address(dai), address(usdc), 1e12 - 1), 0);
-        assertEq(psm.previewSwapExactIn(address(dai), address(usdc), 1e12),     1);
+        assertEq(psm.previewSwapExactIn(address(usds), address(usdc), 1e12 - 1), 0);
+        assertEq(psm.previewSwapExactIn(address(usds), address(usdc), 1e12),     1);
 
-        assertEq(psm.previewSwapExactIn(address(dai), address(usdc), 1e18), 1e6);
-        assertEq(psm.previewSwapExactIn(address(dai), address(usdc), 2e18), 2e6);
-        assertEq(psm.previewSwapExactIn(address(dai), address(usdc), 3e18), 3e6);
+        assertEq(psm.previewSwapExactIn(address(usds), address(usdc), 1e18), 1e6);
+        assertEq(psm.previewSwapExactIn(address(usds), address(usdc), 2e18), 2e6);
+        assertEq(psm.previewSwapExactIn(address(usds), address(usdc), 3e18), 3e6);
     }
 
-    function testFuzz_previewSwapExactIn_daiToUsdc(uint256 amountIn) public view {
-        amountIn = _bound(amountIn, 0, DAI_TOKEN_MAX);
+    function testFuzz_previewSwapExactIn_usdsToUsdc(uint256 amountIn) public view {
+        amountIn = _bound(amountIn, 0, USDS_TOKEN_MAX);
 
-        assertEq(psm.previewSwapExactIn(address(dai), address(usdc), amountIn), amountIn / 1e12);
+        assertEq(psm.previewSwapExactIn(address(usds), address(usdc), amountIn), amountIn / 1e12);
     }
 
-    function test_previewSwapExactIn_daiToSDai() public view {
+    function test_previewSwapExactIn_usdsToSDai() public view {
         // Demo rounding down
-        assertEq(psm.previewSwapExactIn(address(dai), address(sDai), 1e18 - 1), 0.8e18 - 1);
-        assertEq(psm.previewSwapExactIn(address(dai), address(sDai), 1e18),     0.8e18);
-        assertEq(psm.previewSwapExactIn(address(dai), address(sDai), 1e18 + 1), 0.8e18);
+        assertEq(psm.previewSwapExactIn(address(usds), address(susds), 1e18 - 1), 0.8e18 - 1);
+        assertEq(psm.previewSwapExactIn(address(usds), address(susds), 1e18),     0.8e18);
+        assertEq(psm.previewSwapExactIn(address(usds), address(susds), 1e18 + 1), 0.8e18);
 
-        assertEq(psm.previewSwapExactIn(address(dai), address(sDai), 1e18), 0.8e18);
-        assertEq(psm.previewSwapExactIn(address(dai), address(sDai), 2e18), 1.6e18);
-        assertEq(psm.previewSwapExactIn(address(dai), address(sDai), 3e18), 2.4e18);
+        assertEq(psm.previewSwapExactIn(address(usds), address(susds), 1e18), 0.8e18);
+        assertEq(psm.previewSwapExactIn(address(usds), address(susds), 2e18), 1.6e18);
+        assertEq(psm.previewSwapExactIn(address(usds), address(susds), 3e18), 2.4e18);
     }
 
-    function testFuzz_previewSwapExactIn_daiToSDai(uint256 amountIn, uint256 conversionRate) public {
-        amountIn       = _bound(amountIn,       1,         DAI_TOKEN_MAX);
+    function testFuzz_previewSwapExactIn_usdsToSDai(uint256 amountIn, uint256 conversionRate) public {
+        amountIn       = _bound(amountIn,       1,         USDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 amountOut = amountIn * 1e27 / conversionRate;
 
-        assertEq(psm.previewSwapExactIn(address(dai), address(sDai), amountIn), amountOut);
+        assertEq(psm.previewSwapExactIn(address(usds), address(susds), amountIn), amountOut);
     }
 
 }
 
 contract PSMPreviewSwapExactOut_DaiAssetInTests is PSMTestBase {
 
-    function test_previewSwapExactOut_daiToUsdc() public view {
+    function test_previewSwapExactOut_usdsToUsdc() public view {
         // Demo rounding up
-        assertEq(psm.previewSwapExactOut(address(dai), address(usdc), 1e6 - 1), 0.999999e18);
-        assertEq(psm.previewSwapExactOut(address(dai), address(usdc), 1e6),     1e18);
-        assertEq(psm.previewSwapExactOut(address(dai), address(usdc), 1e6 + 1), 1.000001e18);
+        assertEq(psm.previewSwapExactOut(address(usds), address(usdc), 1e6 - 1), 0.999999e18);
+        assertEq(psm.previewSwapExactOut(address(usds), address(usdc), 1e6),     1e18);
+        assertEq(psm.previewSwapExactOut(address(usds), address(usdc), 1e6 + 1), 1.000001e18);
 
-        assertEq(psm.previewSwapExactOut(address(dai), address(usdc), 1e6), 1e18);
-        assertEq(psm.previewSwapExactOut(address(dai), address(usdc), 2e6), 2e18);
-        assertEq(psm.previewSwapExactOut(address(dai), address(usdc), 3e6), 3e18);
+        assertEq(psm.previewSwapExactOut(address(usds), address(usdc), 1e6), 1e18);
+        assertEq(psm.previewSwapExactOut(address(usds), address(usdc), 2e6), 2e18);
+        assertEq(psm.previewSwapExactOut(address(usds), address(usdc), 3e6), 3e18);
     }
 
-    function testFuzz_previewSwapExactOut_daiToUsdc(uint256 amountOut) public view {
+    function testFuzz_previewSwapExactOut_usdsToUsdc(uint256 amountOut) public view {
         amountOut = _bound(amountOut, 0, USDC_TOKEN_MAX);
 
-        assertEq(psm.previewSwapExactOut(address(dai), address(usdc), amountOut), amountOut * 1e12);
+        assertEq(psm.previewSwapExactOut(address(usds), address(usdc), amountOut), amountOut * 1e12);
     }
 
-    function test_previewSwapExactOut_daiToSDai() public view {
+    function test_previewSwapExactOut_usdsToSDai() public view {
         // Demo rounding up
-        assertEq(psm.previewSwapExactOut(address(dai), address(sDai), 1e18 - 1), 1.25e18 - 1);
-        assertEq(psm.previewSwapExactOut(address(dai), address(sDai), 1e18),     1.25e18);
-        assertEq(psm.previewSwapExactOut(address(dai), address(sDai), 1e18 + 1), 1.25e18 + 2);
+        assertEq(psm.previewSwapExactOut(address(usds), address(susds), 1e18 - 1), 1.25e18 - 1);
+        assertEq(psm.previewSwapExactOut(address(usds), address(susds), 1e18),     1.25e18);
+        assertEq(psm.previewSwapExactOut(address(usds), address(susds), 1e18 + 1), 1.25e18 + 2);
 
-        assertEq(psm.previewSwapExactOut(address(dai), address(sDai), 0.8e18), 1e18);
-        assertEq(psm.previewSwapExactOut(address(dai), address(sDai), 1.6e18), 2e18);
-        assertEq(psm.previewSwapExactOut(address(dai), address(sDai), 2.4e18), 3e18);
+        assertEq(psm.previewSwapExactOut(address(usds), address(susds), 0.8e18), 1e18);
+        assertEq(psm.previewSwapExactOut(address(usds), address(susds), 1.6e18), 2e18);
+        assertEq(psm.previewSwapExactOut(address(usds), address(susds), 2.4e18), 3e18);
     }
 
-    function testFuzz_previewSwapExactOut_daiToSDai(uint256 amountOut, uint256 conversionRate) public {
+    function testFuzz_previewSwapExactOut_usdsToSDai(uint256 amountOut, uint256 conversionRate) public {
         amountOut      = _bound(amountOut,      1,         USDC_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
@@ -147,7 +147,7 @@ contract PSMPreviewSwapExactOut_DaiAssetInTests is PSMTestBase {
 
         uint256 expectedAmountIn = amountOut * conversionRate / 1e27;
 
-        uint256 amountIn = psm.previewSwapExactOut(address(dai), address(sDai), amountOut);
+        uint256 amountIn = psm.previewSwapExactOut(address(usds), address(susds), amountOut);
 
         // Allow for rounding error of 1 unit upwards
         assertLe(amountIn - expectedAmountIn, 1);
@@ -159,30 +159,30 @@ contract PSMPreviewSwapExactIn_USDCAssetInTests is PSMTestBase {
 
     function test_previewSwapExactIn_usdcToDai() public view {
         // Demo rounding down
-        assertEq(psm.previewSwapExactIn(address(usdc), address(dai), 1e6 - 1), 0.999999e18);
-        assertEq(psm.previewSwapExactIn(address(usdc), address(dai), 1e6),     1e18);
-        assertEq(psm.previewSwapExactIn(address(usdc), address(dai), 1e6 + 1), 1.000001e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(usds), 1e6 - 1), 0.999999e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(usds), 1e6),     1e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(usds), 1e6 + 1), 1.000001e18);
 
-        assertEq(psm.previewSwapExactIn(address(usdc), address(dai), 1e6), 1e18);
-        assertEq(psm.previewSwapExactIn(address(usdc), address(dai), 2e6), 2e18);
-        assertEq(psm.previewSwapExactIn(address(usdc), address(dai), 3e6), 3e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(usds), 1e6), 1e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(usds), 2e6), 2e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(usds), 3e6), 3e18);
     }
 
     function testFuzz_previewSwapExactIn_usdcToDai(uint256 amountIn) public view {
         amountIn = _bound(amountIn, 0, USDC_TOKEN_MAX);
 
-        assertEq(psm.previewSwapExactIn(address(usdc), address(dai), amountIn), amountIn * 1e12);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(usds), amountIn), amountIn * 1e12);
     }
 
     function test_previewSwapExactIn_usdcToSDai() public view {
         // Demo rounding down
-        assertEq(psm.previewSwapExactIn(address(usdc), address(sDai), 1e6 - 1), 0.799999e18);
-        assertEq(psm.previewSwapExactIn(address(usdc), address(sDai), 1e6),     0.8e18);
-        assertEq(psm.previewSwapExactIn(address(usdc), address(sDai), 1e6 + 1), 0.8e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(susds), 1e6 - 1), 0.799999e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(susds), 1e6),     0.8e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(susds), 1e6 + 1), 0.8e18);
 
-        assertEq(psm.previewSwapExactIn(address(usdc), address(sDai), 1e6), 0.8e18);
-        assertEq(psm.previewSwapExactIn(address(usdc), address(sDai), 2e6), 1.6e18);
-        assertEq(psm.previewSwapExactIn(address(usdc), address(sDai), 3e6), 2.4e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(susds), 1e6), 0.8e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(susds), 2e6), 1.6e18);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(susds), 3e6), 2.4e18);
     }
 
     function testFuzz_previewSwapExactIn_usdcToSDai(uint256 amountIn, uint256 conversionRate) public {
@@ -193,7 +193,7 @@ contract PSMPreviewSwapExactIn_USDCAssetInTests is PSMTestBase {
 
         uint256 amountOut = amountIn * 1e27 / conversionRate * 1e12;
 
-        assertEq(psm.previewSwapExactIn(address(usdc), address(sDai), amountIn), amountOut);
+        assertEq(psm.previewSwapExactIn(address(usdc), address(susds), amountIn), amountOut);
     }
 
 }
@@ -202,19 +202,19 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
 
     function test_previewSwapExactOut_usdcToDai() public view {
         // Demo rounding up
-        assertEq(psm.previewSwapExactOut(address(usdc), address(dai), 1e18 - 1), 1e6);
-        assertEq(psm.previewSwapExactOut(address(usdc), address(dai), 1e18),     1e6);
-        assertEq(psm.previewSwapExactOut(address(usdc), address(dai), 1e18 + 1), 1e6 + 1);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(usds), 1e18 - 1), 1e6);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(usds), 1e18),     1e6);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(usds), 1e18 + 1), 1e6 + 1);
 
-        assertEq(psm.previewSwapExactOut(address(usdc), address(dai), 1e18), 1e6);
-        assertEq(psm.previewSwapExactOut(address(usdc), address(dai), 2e18), 2e6);
-        assertEq(psm.previewSwapExactOut(address(usdc), address(dai), 3e18), 3e6);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(usds), 1e18), 1e6);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(usds), 2e18), 2e6);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(usds), 3e18), 3e6);
     }
 
     function testFuzz_previewSwapExactOut_usdcToDai(uint256 amountOut) public view {
-        amountOut = _bound(amountOut, 0, DAI_TOKEN_MAX);
+        amountOut = _bound(amountOut, 0, USDS_TOKEN_MAX);
 
-        uint256 amountIn = psm.previewSwapExactOut(address(usdc), address(dai), amountOut);
+        uint256 amountIn = psm.previewSwapExactOut(address(usdc), address(usds), amountOut);
 
         // Allow for rounding error of 1 unit upwards
         assertLe(amountIn - amountOut / 1e12, 1);
@@ -222,17 +222,17 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
 
     function test_previewSwapExactOut_usdcToSDai() public view {
         // Demo rounding up
-        assertEq(psm.previewSwapExactOut(address(usdc), address(sDai), 1e18 - 1), 1.25e6);
-        assertEq(psm.previewSwapExactOut(address(usdc), address(sDai), 1e18),     1.25e6);
-        assertEq(psm.previewSwapExactOut(address(usdc), address(sDai), 1e18 + 1), 1.25e6 + 1);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(susds), 1e18 - 1), 1.25e6);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(susds), 1e18),     1.25e6);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(susds), 1e18 + 1), 1.25e6 + 1);
 
-        assertEq(psm.previewSwapExactOut(address(usdc), address(sDai), 0.8e18), 1e6);
-        assertEq(psm.previewSwapExactOut(address(usdc), address(sDai), 1.6e18), 2e6);
-        assertEq(psm.previewSwapExactOut(address(usdc), address(sDai), 2.4e18), 3e6);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(susds), 0.8e18), 1e6);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(susds), 1.6e18), 2e6);
+        assertEq(psm.previewSwapExactOut(address(usdc), address(susds), 2.4e18), 3e6);
     }
 
     function testFuzz_previewSwapExactOut_usdcToSDai(uint256 amountOut, uint256 conversionRate) public {
-        amountOut      = _bound(amountOut,     1,         SDAI_TOKEN_MAX);
+        amountOut      = _bound(amountOut,     1,         SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
         mockRateProvider.__setConversionRate(conversionRate);
@@ -240,17 +240,17 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
         // Using raw calculation to demo rounding
         uint256 expectedAmountIn = amountOut * conversionRate / 1e27 / 1e12;
 
-        uint256 amountIn = psm.previewSwapExactOut(address(usdc), address(sDai), amountOut);
+        uint256 amountIn = psm.previewSwapExactOut(address(usdc), address(susds), amountOut);
 
         // Allow for rounding error of 1 unit upwards
         assertLe(amountIn - expectedAmountIn, 1);
     }
 
     function test_demoRoundingUp_usdcToSDai() public view {
-        uint256 expectedAmountIn1 = psm.previewSwapExactOut(address(usdc), address(sDai), 0.8e18);
-        uint256 expectedAmountIn2 = psm.previewSwapExactOut(address(usdc), address(sDai), 0.8e18 + 1);
-        uint256 expectedAmountIn3 = psm.previewSwapExactOut(address(usdc), address(sDai), 0.8e18 + 0.8e12);
-        uint256 expectedAmountIn4 = psm.previewSwapExactOut(address(usdc), address(sDai), 0.8e18 + 0.8e12 + 1);
+        uint256 expectedAmountIn1 = psm.previewSwapExactOut(address(usdc), address(susds), 0.8e18);
+        uint256 expectedAmountIn2 = psm.previewSwapExactOut(address(usdc), address(susds), 0.8e18 + 1);
+        uint256 expectedAmountIn3 = psm.previewSwapExactOut(address(usdc), address(susds), 0.8e18 + 0.8e12);
+        uint256 expectedAmountIn4 = psm.previewSwapExactOut(address(usdc), address(susds), 0.8e18 + 0.8e12 + 1);
 
         assertEq(expectedAmountIn1, 1e6);
         assertEq(expectedAmountIn2, 1e6 + 1);
@@ -259,10 +259,10 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
     }
 
     function test_demoRoundingUp_usdcToDai() public view {
-        uint256 expectedAmountIn1 = psm.previewSwapExactOut(address(usdc), address(dai), 1e18);
-        uint256 expectedAmountIn2 = psm.previewSwapExactOut(address(usdc), address(dai), 1e18 + 1);
-        uint256 expectedAmountIn3 = psm.previewSwapExactOut(address(usdc), address(dai), 1e18 + 1e12);
-        uint256 expectedAmountIn4 = psm.previewSwapExactOut(address(usdc), address(dai), 1e18 + 1e12 + 1);
+        uint256 expectedAmountIn1 = psm.previewSwapExactOut(address(usdc), address(usds), 1e18);
+        uint256 expectedAmountIn2 = psm.previewSwapExactOut(address(usdc), address(usds), 1e18 + 1);
+        uint256 expectedAmountIn3 = psm.previewSwapExactOut(address(usdc), address(usds), 1e18 + 1e12);
+        uint256 expectedAmountIn4 = psm.previewSwapExactOut(address(usdc), address(usds), 1e18 + 1e12 + 1);
 
         assertEq(expectedAmountIn1, 1e6);
         assertEq(expectedAmountIn2, 1e6 + 1);
@@ -274,91 +274,91 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
 
 contract PSMPreviewSwapExactIn_SDaiAssetInTests is PSMTestBase {
 
-    function test_previewSwapExactIn_sDaiToDai() public view {
+    function test_previewSwapExactIn_susdsToDai() public view {
         // Demo rounding down
-        assertEq(psm.previewSwapExactIn(address(sDai), address(dai), 1e18 - 1), 1.25e18 - 2);
-        assertEq(psm.previewSwapExactIn(address(sDai), address(dai), 1e18),     1.25e18);
-        assertEq(psm.previewSwapExactIn(address(sDai), address(dai), 1e18 + 1), 1.25e18 + 1);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usds), 1e18 - 1), 1.25e18 - 2);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usds), 1e18),     1.25e18);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usds), 1e18 + 1), 1.25e18 + 1);
 
-        assertEq(psm.previewSwapExactIn(address(sDai), address(dai), 1e18), 1.25e18);
-        assertEq(psm.previewSwapExactIn(address(sDai), address(dai), 2e18), 2.5e18);
-        assertEq(psm.previewSwapExactIn(address(sDai), address(dai), 3e18), 3.75e18);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usds), 1e18), 1.25e18);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usds), 2e18), 2.5e18);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usds), 3e18), 3.75e18);
     }
 
-    function testFuzz_previewSwapExactIn_sDaiToDai(uint256 amountIn, uint256 conversionRate) public {
-        amountIn       = _bound(amountIn,       1,         SDAI_TOKEN_MAX);
+    function testFuzz_previewSwapExactIn_susdsToDai(uint256 amountIn, uint256 conversionRate) public {
+        amountIn       = _bound(amountIn,       1,         SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 amountOut = amountIn * conversionRate / 1e27;
 
-        assertEq(psm.previewSwapExactIn(address(sDai), address(dai), amountIn), amountOut);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usds), amountIn), amountOut);
     }
 
-    function test_previewSwapExactIn_sDaiToUsdc() public view {
+    function test_previewSwapExactIn_susdsToUsdc() public view {
         // Demo rounding down
-        assertEq(psm.previewSwapExactIn(address(sDai), address(usdc), 1e18 - 1), 1.25e6 - 1);
-        assertEq(psm.previewSwapExactIn(address(sDai), address(usdc), 1e18),     1.25e6);
-        assertEq(psm.previewSwapExactIn(address(sDai), address(usdc), 1e18 + 1), 1.25e6);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usdc), 1e18 - 1), 1.25e6 - 1);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usdc), 1e18),     1.25e6);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usdc), 1e18 + 1), 1.25e6);
 
-        assertEq(psm.previewSwapExactIn(address(sDai), address(usdc), 1e18), 1.25e6);
-        assertEq(psm.previewSwapExactIn(address(sDai), address(usdc), 2e18), 2.5e6);
-        assertEq(psm.previewSwapExactIn(address(sDai), address(usdc), 3e18), 3.75e6);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usdc), 1e18), 1.25e6);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usdc), 2e18), 2.5e6);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usdc), 3e18), 3.75e6);
     }
 
-    function testFuzz_previewSwapExactIn_sDaiToUsdc(uint256 amountIn, uint256 conversionRate) public {
-        amountIn       = _bound(amountIn,       1,         SDAI_TOKEN_MAX);
+    function testFuzz_previewSwapExactIn_susdsToUsdc(uint256 amountIn, uint256 conversionRate) public {
+        amountIn       = _bound(amountIn,       1,         SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 amountOut = amountIn * conversionRate / 1e27 / 1e12;
 
-        assertEq(psm.previewSwapExactIn(address(sDai), address(usdc), amountIn), amountOut);
+        assertEq(psm.previewSwapExactIn(address(susds), address(usdc), amountIn), amountOut);
     }
 
 }
 
 contract PSMPreviewSwapExactOut_SDaiAssetInTests is PSMTestBase {
 
-    function test_previewSwapExactOut_sDaiToDai() public view {
+    function test_previewSwapExactOut_susdsToDai() public view {
         // Demo rounding up
-        assertEq(psm.previewSwapExactOut(address(sDai), address(dai), 1e18 - 1), 0.8e18);
-        assertEq(psm.previewSwapExactOut(address(sDai), address(dai), 1e18),     0.8e18);
-        assertEq(psm.previewSwapExactOut(address(sDai), address(dai), 1e18 + 1), 0.8e18 + 1);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usds), 1e18 - 1), 0.8e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usds), 1e18),     0.8e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usds), 1e18 + 1), 0.8e18 + 1);
 
-        assertEq(psm.previewSwapExactOut(address(sDai), address(dai), 1.25e18), 1e18);
-        assertEq(psm.previewSwapExactOut(address(sDai), address(dai), 2.5e18),  2e18);
-        assertEq(psm.previewSwapExactOut(address(sDai), address(dai), 3.75e18), 3e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usds), 1.25e18), 1e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usds), 2.5e18),  2e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usds), 3.75e18), 3e18);
     }
 
-    function testFuzz_previewSwapExactOut_sDaiToDai(uint256 amountOut, uint256 conversionRate) public {
-        amountOut      = _bound(amountOut,      1,         DAI_TOKEN_MAX);
+    function testFuzz_previewSwapExactOut_susdsToDai(uint256 amountOut, uint256 conversionRate) public {
+        amountOut      = _bound(amountOut,      1,         USDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 expectedAmountIn = amountOut * 1e27 / conversionRate;
 
-        uint256 amountIn = psm.previewSwapExactOut(address(sDai), address(dai), amountOut);
+        uint256 amountIn = psm.previewSwapExactOut(address(susds), address(usds), amountOut);
 
         // Allow for rounding error of 1 unit upwards
         assertLe(amountIn - expectedAmountIn, 1);
     }
 
-    function test_previewSwapExactOut_sDaiToUsdc() public view {
+    function test_previewSwapExactOut_susdsToUsdc() public view {
         // Demo rounding up
-        assertEq(psm.previewSwapExactOut(address(sDai), address(usdc), 1e6 - 1), 0.8e18);
-        assertEq(psm.previewSwapExactOut(address(sDai), address(usdc), 1e6),     0.8e18);
-        assertEq(psm.previewSwapExactOut(address(sDai), address(usdc), 1e6 + 1), 0.800001e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usdc), 1e6 - 1), 0.8e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usdc), 1e6),     0.8e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usdc), 1e6 + 1), 0.800001e18);
 
-        assertEq(psm.previewSwapExactOut(address(sDai), address(usdc), 1.25e6), 1e18);
-        assertEq(psm.previewSwapExactOut(address(sDai), address(usdc), 2.5e6),  2e18);
-        assertEq(psm.previewSwapExactOut(address(sDai), address(usdc), 3.75e6), 3e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usdc), 1.25e6), 1e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usdc), 2.5e6),  2e18);
+        assertEq(psm.previewSwapExactOut(address(susds), address(usdc), 3.75e6), 3e18);
     }
 
-    function testFuzz_previewSwapExactOut_sDaiToUsdc(uint256 amountOut, uint256 conversionRate) public {
+    function testFuzz_previewSwapExactOut_susdsToUsdc(uint256 amountOut, uint256 conversionRate) public {
         amountOut      = bound(amountOut,      1,         USDC_TOKEN_MAX);
         conversionRate = bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
@@ -366,7 +366,7 @@ contract PSMPreviewSwapExactOut_SDaiAssetInTests is PSMTestBase {
 
         uint256 expectedAmountIn = amountOut * 1e27 / conversionRate * 1e12;
 
-        uint256 amountIn = psm.previewSwapExactOut(address(sDai), address(usdc), amountOut);
+        uint256 amountIn = psm.previewSwapExactOut(address(susds), address(usdc), amountOut);
 
         // Allow for rounding error of 1e12 upwards
         assertLe(amountIn - expectedAmountIn, 1e12);

--- a/test/unit/SwapPreviews.t.sol
+++ b/test/unit/SwapPreviews.t.sol
@@ -63,7 +63,7 @@ contract PSMPreviewSwapExactOut_FailureTests is PSMTestBase {
 
 }
 
-contract PSMPreviewSwapExactIn_DaiAssetInTests is PSMTestBase {
+contract PSMPreviewSwapExactIn_UsdsAssetInTests is PSMTestBase {
 
     function test_previewSwapExactIn_usdsToUsdc() public view {
         // Demo rounding down
@@ -85,7 +85,7 @@ contract PSMPreviewSwapExactIn_DaiAssetInTests is PSMTestBase {
         assertEq(psm.previewSwapExactIn(address(usds), address(usdc), amountIn), amountIn / 1e12);
     }
 
-    function test_previewSwapExactIn_usdsToSDai() public view {
+    function test_previewSwapExactIn_usdsToSUsds() public view {
         // Demo rounding down
         assertEq(psm.previewSwapExactIn(address(usds), address(susds), 1e18 - 1), 0.8e18 - 1);
         assertEq(psm.previewSwapExactIn(address(usds), address(susds), 1e18),     0.8e18);
@@ -96,7 +96,7 @@ contract PSMPreviewSwapExactIn_DaiAssetInTests is PSMTestBase {
         assertEq(psm.previewSwapExactIn(address(usds), address(susds), 3e18), 2.4e18);
     }
 
-    function testFuzz_previewSwapExactIn_usdsToSDai(uint256 amountIn, uint256 conversionRate) public {
+    function testFuzz_previewSwapExactIn_usdsToSUsds(uint256 amountIn, uint256 conversionRate) public {
         amountIn       = _bound(amountIn,       1,         USDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
@@ -109,7 +109,7 @@ contract PSMPreviewSwapExactIn_DaiAssetInTests is PSMTestBase {
 
 }
 
-contract PSMPreviewSwapExactOut_DaiAssetInTests is PSMTestBase {
+contract PSMPreviewSwapExactOut_UsdsAssetInTests is PSMTestBase {
 
     function test_previewSwapExactOut_usdsToUsdc() public view {
         // Demo rounding up
@@ -128,7 +128,7 @@ contract PSMPreviewSwapExactOut_DaiAssetInTests is PSMTestBase {
         assertEq(psm.previewSwapExactOut(address(usds), address(usdc), amountOut), amountOut * 1e12);
     }
 
-    function test_previewSwapExactOut_usdsToSDai() public view {
+    function test_previewSwapExactOut_usdsToSUsds() public view {
         // Demo rounding up
         assertEq(psm.previewSwapExactOut(address(usds), address(susds), 1e18 - 1), 1.25e18 - 1);
         assertEq(psm.previewSwapExactOut(address(usds), address(susds), 1e18),     1.25e18);
@@ -139,7 +139,7 @@ contract PSMPreviewSwapExactOut_DaiAssetInTests is PSMTestBase {
         assertEq(psm.previewSwapExactOut(address(usds), address(susds), 2.4e18), 3e18);
     }
 
-    function testFuzz_previewSwapExactOut_usdsToSDai(uint256 amountOut, uint256 conversionRate) public {
+    function testFuzz_previewSwapExactOut_usdsToSUsds(uint256 amountOut, uint256 conversionRate) public {
         amountOut      = _bound(amountOut,      1,         USDC_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
@@ -157,7 +157,7 @@ contract PSMPreviewSwapExactOut_DaiAssetInTests is PSMTestBase {
 
 contract PSMPreviewSwapExactIn_USDCAssetInTests is PSMTestBase {
 
-    function test_previewSwapExactIn_usdcToDai() public view {
+    function test_previewSwapExactIn_usdcToUsds() public view {
         // Demo rounding down
         assertEq(psm.previewSwapExactIn(address(usdc), address(usds), 1e6 - 1), 0.999999e18);
         assertEq(psm.previewSwapExactIn(address(usdc), address(usds), 1e6),     1e18);
@@ -168,13 +168,13 @@ contract PSMPreviewSwapExactIn_USDCAssetInTests is PSMTestBase {
         assertEq(psm.previewSwapExactIn(address(usdc), address(usds), 3e6), 3e18);
     }
 
-    function testFuzz_previewSwapExactIn_usdcToDai(uint256 amountIn) public view {
+    function testFuzz_previewSwapExactIn_usdcToUsds(uint256 amountIn) public view {
         amountIn = _bound(amountIn, 0, USDC_TOKEN_MAX);
 
         assertEq(psm.previewSwapExactIn(address(usdc), address(usds), amountIn), amountIn * 1e12);
     }
 
-    function test_previewSwapExactIn_usdcToSDai() public view {
+    function test_previewSwapExactIn_usdcToSUsds() public view {
         // Demo rounding down
         assertEq(psm.previewSwapExactIn(address(usdc), address(susds), 1e6 - 1), 0.799999e18);
         assertEq(psm.previewSwapExactIn(address(usdc), address(susds), 1e6),     0.8e18);
@@ -185,7 +185,7 @@ contract PSMPreviewSwapExactIn_USDCAssetInTests is PSMTestBase {
         assertEq(psm.previewSwapExactIn(address(usdc), address(susds), 3e6), 2.4e18);
     }
 
-    function testFuzz_previewSwapExactIn_usdcToSDai(uint256 amountIn, uint256 conversionRate) public {
+    function testFuzz_previewSwapExactIn_usdcToSUsds(uint256 amountIn, uint256 conversionRate) public {
         amountIn       = _bound(amountIn,       1,         USDC_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
@@ -200,7 +200,7 @@ contract PSMPreviewSwapExactIn_USDCAssetInTests is PSMTestBase {
 
 contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
 
-    function test_previewSwapExactOut_usdcToDai() public view {
+    function test_previewSwapExactOut_usdcToUsds() public view {
         // Demo rounding up
         assertEq(psm.previewSwapExactOut(address(usdc), address(usds), 1e18 - 1), 1e6);
         assertEq(psm.previewSwapExactOut(address(usdc), address(usds), 1e18),     1e6);
@@ -211,7 +211,7 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
         assertEq(psm.previewSwapExactOut(address(usdc), address(usds), 3e18), 3e6);
     }
 
-    function testFuzz_previewSwapExactOut_usdcToDai(uint256 amountOut) public view {
+    function testFuzz_previewSwapExactOut_usdcToUsds(uint256 amountOut) public view {
         amountOut = _bound(amountOut, 0, USDS_TOKEN_MAX);
 
         uint256 amountIn = psm.previewSwapExactOut(address(usdc), address(usds), amountOut);
@@ -220,7 +220,7 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
         assertLe(amountIn - amountOut / 1e12, 1);
     }
 
-    function test_previewSwapExactOut_usdcToSDai() public view {
+    function test_previewSwapExactOut_usdcToSUsds() public view {
         // Demo rounding up
         assertEq(psm.previewSwapExactOut(address(usdc), address(susds), 1e18 - 1), 1.25e6);
         assertEq(psm.previewSwapExactOut(address(usdc), address(susds), 1e18),     1.25e6);
@@ -231,7 +231,7 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
         assertEq(psm.previewSwapExactOut(address(usdc), address(susds), 2.4e18), 3e6);
     }
 
-    function testFuzz_previewSwapExactOut_usdcToSDai(uint256 amountOut, uint256 conversionRate) public {
+    function testFuzz_previewSwapExactOut_usdcToSUsds(uint256 amountOut, uint256 conversionRate) public {
         amountOut      = _bound(amountOut,     1,         SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
@@ -246,7 +246,7 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
         assertLe(amountIn - expectedAmountIn, 1);
     }
 
-    function test_demoRoundingUp_usdcToSDai() public view {
+    function test_demoRoundingUp_usdcToSUsds() public view {
         uint256 expectedAmountIn1 = psm.previewSwapExactOut(address(usdc), address(susds), 0.8e18);
         uint256 expectedAmountIn2 = psm.previewSwapExactOut(address(usdc), address(susds), 0.8e18 + 1);
         uint256 expectedAmountIn3 = psm.previewSwapExactOut(address(usdc), address(susds), 0.8e18 + 0.8e12);
@@ -258,7 +258,7 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
         assertEq(expectedAmountIn4, 1e6 + 2);
     }
 
-    function test_demoRoundingUp_usdcToDai() public view {
+    function test_demoRoundingUp_usdcToUsds() public view {
         uint256 expectedAmountIn1 = psm.previewSwapExactOut(address(usdc), address(usds), 1e18);
         uint256 expectedAmountIn2 = psm.previewSwapExactOut(address(usdc), address(usds), 1e18 + 1);
         uint256 expectedAmountIn3 = psm.previewSwapExactOut(address(usdc), address(usds), 1e18 + 1e12);
@@ -272,9 +272,9 @@ contract PSMPreviewSwapExactOut_USDCAssetInTests is PSMTestBase {
 
 }
 
-contract PSMPreviewSwapExactIn_SDaiAssetInTests is PSMTestBase {
+contract PSMPreviewSwapExactIn_SUsdsAssetInTests is PSMTestBase {
 
-    function test_previewSwapExactIn_susdsToDai() public view {
+    function test_previewSwapExactIn_susdsToUsds() public view {
         // Demo rounding down
         assertEq(psm.previewSwapExactIn(address(susds), address(usds), 1e18 - 1), 1.25e18 - 2);
         assertEq(psm.previewSwapExactIn(address(susds), address(usds), 1e18),     1.25e18);
@@ -285,7 +285,7 @@ contract PSMPreviewSwapExactIn_SDaiAssetInTests is PSMTestBase {
         assertEq(psm.previewSwapExactIn(address(susds), address(usds), 3e18), 3.75e18);
     }
 
-    function testFuzz_previewSwapExactIn_susdsToDai(uint256 amountIn, uint256 conversionRate) public {
+    function testFuzz_previewSwapExactIn_susdsToUsds(uint256 amountIn, uint256 conversionRate) public {
         amountIn       = _bound(amountIn,       1,         SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 
@@ -320,9 +320,9 @@ contract PSMPreviewSwapExactIn_SDaiAssetInTests is PSMTestBase {
 
 }
 
-contract PSMPreviewSwapExactOut_SDaiAssetInTests is PSMTestBase {
+contract PSMPreviewSwapExactOut_SUsdsAssetInTests is PSMTestBase {
 
-    function test_previewSwapExactOut_susdsToDai() public view {
+    function test_previewSwapExactOut_susdsToUsds() public view {
         // Demo rounding up
         assertEq(psm.previewSwapExactOut(address(susds), address(usds), 1e18 - 1), 0.8e18);
         assertEq(psm.previewSwapExactOut(address(susds), address(usds), 1e18),     0.8e18);
@@ -333,7 +333,7 @@ contract PSMPreviewSwapExactOut_SDaiAssetInTests is PSMTestBase {
         assertEq(psm.previewSwapExactOut(address(susds), address(usds), 3.75e18), 3e18);
     }
 
-    function testFuzz_previewSwapExactOut_susdsToDai(uint256 amountOut, uint256 conversionRate) public {
+    function testFuzz_previewSwapExactOut_susdsToUsds(uint256 amountOut, uint256 conversionRate) public {
         amountOut      = _bound(amountOut,      1,         USDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);  // 0.01% to 100,000% conversion rate
 

--- a/test/unit/SwapPreviews.t.sol
+++ b/test/unit/SwapPreviews.t.sol
@@ -17,17 +17,17 @@ contract PSMPreviewSwapExactIn_FailureTests is PSMTestBase {
         psm.previewSwapExactIn(address(usdc), makeAddr("other-token"), 1);
     }
 
-    function test_previewSwapExactIn_bothAsset0() public {
-        vm.expectRevert("PSM3/invalid-asset");
-        psm.previewSwapExactIn(address(dai), address(dai), 1);
-    }
-
-    function test_previewSwapExactIn_bothAsset1() public {
+    function test_previewSwapExactIn_bothUsdc() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.previewSwapExactIn(address(usdc), address(usdc), 1);
     }
 
-    function test_previewSwapExactIn_bothAsset2() public {
+    function test_previewSwapExactIn_bothUsds() public {
+        vm.expectRevert("PSM3/invalid-asset");
+        psm.previewSwapExactIn(address(dai), address(dai), 1);
+    }
+
+    function test_previewSwapExactIn_bothSUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.previewSwapExactIn(address(sDai), address(sDai), 1);
     }
@@ -46,17 +46,17 @@ contract PSMPreviewSwapExactOut_FailureTests is PSMTestBase {
         psm.previewSwapExactOut(address(usdc), makeAddr("other-token"), 1);
     }
 
-    function test_previewSwapExactOut_bothAsset0() public {
+    function test_previewSwapExactOut_bothUsdc() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.previewSwapExactOut(address(dai), address(dai), 1);
     }
 
-    function test_previewSwapExactOut_bothAsset1() public {
+    function test_previewSwapExactOut_bothUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.previewSwapExactOut(address(usdc), address(usdc), 1);
     }
 
-    function test_previewSwapExactOut_bothAsset2() public {
+    function test_previewSwapExactOut_bothSUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.previewSwapExactOut(address(sDai), address(sDai), 1);
     }

--- a/test/unit/Withdraw.t.sol
+++ b/test/unit/Withdraw.t.sol
@@ -29,11 +29,11 @@ contract PSMWithdrawTests is PSMTestBase {
     }
 
     function test_withdraw_onlyDaiInPsm() public {
-        _deposit(address(dai), user1, 100e18);
+        _deposit(address(usds), user1, 100e18);
 
-        assertEq(dai.balanceOf(user1),        0);
-        assertEq(dai.balanceOf(receiver1),    0);
-        assertEq(dai.balanceOf(address(psm)), 100e18);
+        assertEq(usds.balanceOf(user1),        0);
+        assertEq(usds.balanceOf(receiver1),    0);
+        assertEq(usds.balanceOf(address(psm)), 100e18);
 
         assertEq(psm.totalShares(), 100e18);
         assertEq(psm.shares(user1), 100e18);
@@ -41,13 +41,13 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(psm.convertToShares(1e18), 1e18);
 
         vm.prank(user1);
-        uint256 amount = psm.withdraw(address(dai), receiver1, 100e18);
+        uint256 amount = psm.withdraw(address(usds), receiver1, 100e18);
 
         assertEq(amount, 100e18);
 
-        assertEq(dai.balanceOf(user1),        0);
-        assertEq(dai.balanceOf(receiver1),    100e18);
-        assertEq(dai.balanceOf(address(psm)), 0);
+        assertEq(usds.balanceOf(user1),        0);
+        assertEq(usds.balanceOf(receiver1),    100e18);
+        assertEq(usds.balanceOf(address(psm)), 0);
 
         assertEq(psm.totalShares(), 0);
         assertEq(psm.shares(user1), 0);
@@ -83,11 +83,11 @@ contract PSMWithdrawTests is PSMTestBase {
     }
 
     function test_withdraw_onlySDaiInPsm() public {
-        _deposit(address(sDai), user1, 80e18);
+        _deposit(address(susds), user1, 80e18);
 
-        assertEq(sDai.balanceOf(user1),        0);
-        assertEq(sDai.balanceOf(receiver1),    0);
-        assertEq(sDai.balanceOf(address(psm)), 80e18);
+        assertEq(susds.balanceOf(user1),        0);
+        assertEq(susds.balanceOf(receiver1),    0);
+        assertEq(susds.balanceOf(address(psm)), 80e18);
 
         assertEq(psm.totalShares(), 100e18);
         assertEq(psm.shares(user1), 100e18);
@@ -95,13 +95,13 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(psm.convertToShares(1e18), 1e18);
 
         vm.prank(user1);
-        uint256 amount = psm.withdraw(address(sDai), receiver1, 80e18);
+        uint256 amount = psm.withdraw(address(susds), receiver1, 80e18);
 
         assertEq(amount, 80e18);
 
-        assertEq(sDai.balanceOf(user1),        0);
-        assertEq(sDai.balanceOf(receiver1),    80e18);
-        assertEq(sDai.balanceOf(address(psm)), 0);
+        assertEq(susds.balanceOf(user1),        0);
+        assertEq(susds.balanceOf(receiver1),    80e18);
+        assertEq(susds.balanceOf(address(psm)), 0);
 
         assertEq(psm.totalShares(), 0);
         assertEq(psm.shares(user1), 0);
@@ -111,15 +111,15 @@ contract PSMWithdrawTests is PSMTestBase {
 
     function test_withdraw_usdcThenSDai() public {
         _deposit(address(usdc), user1, 100e6);
-        _deposit(address(sDai), user1, 100e18);
+        _deposit(address(susds), user1, 100e18);
 
         assertEq(usdc.balanceOf(user1),        0);
         assertEq(usdc.balanceOf(receiver1),    0);
         assertEq(usdc.balanceOf(address(psm)), 100e6);
 
-        assertEq(sDai.balanceOf(user1),        0);
-        assertEq(sDai.balanceOf(receiver1),    0);
-        assertEq(sDai.balanceOf(address(psm)), 100e18);
+        assertEq(susds.balanceOf(user1),        0);
+        assertEq(susds.balanceOf(receiver1),    0);
+        assertEq(susds.balanceOf(address(psm)), 100e18);
 
         assertEq(psm.totalShares(), 225e18);
         assertEq(psm.shares(user1), 225e18);
@@ -135,9 +135,9 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(usdc.balanceOf(receiver1),    100e6);
         assertEq(usdc.balanceOf(address(psm)), 0);
 
-        assertEq(sDai.balanceOf(user1),        0);
-        assertEq(sDai.balanceOf(receiver1),    0);
-        assertEq(sDai.balanceOf(address(psm)), 100e18);
+        assertEq(susds.balanceOf(user1),        0);
+        assertEq(susds.balanceOf(receiver1),    0);
+        assertEq(susds.balanceOf(address(psm)), 100e18);
 
         assertEq(psm.totalShares(), 125e18);
         assertEq(psm.shares(user1), 125e18);
@@ -145,7 +145,7 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(psm.convertToShares(1e18), 1e18);
 
         vm.prank(user1);
-        amount = psm.withdraw(address(sDai), receiver1, 100e18);
+        amount = psm.withdraw(address(susds), receiver1, 100e18);
 
         assertEq(amount, 100e18);
 
@@ -153,9 +153,9 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(usdc.balanceOf(receiver1),    100e6);
         assertEq(usdc.balanceOf(address(psm)), 0);
 
-        assertEq(sDai.balanceOf(user1),        0);
-        assertEq(sDai.balanceOf(receiver1),    100e18);
-        assertEq(sDai.balanceOf(address(psm)), 0);
+        assertEq(susds.balanceOf(user1),        0);
+        assertEq(susds.balanceOf(receiver1),    100e18);
+        assertEq(susds.balanceOf(address(psm)), 0);
 
         assertEq(psm.totalShares(), 0);
         assertEq(psm.shares(user1), 0);
@@ -164,8 +164,8 @@ contract PSMWithdrawTests is PSMTestBase {
     }
 
     function test_withdraw_amountHigherThanBalanceOfAsset() public {
-        _deposit(address(usdc), user1, 100e6);
-        _deposit(address(sDai), user1, 100e18);
+        _deposit(address(usdc),  user1, 100e6);
+        _deposit(address(susds), user1, 100e18);
 
         assertEq(usdc.balanceOf(user1),        0);
         assertEq(usdc.balanceOf(receiver1),    0);
@@ -190,9 +190,9 @@ contract PSMWithdrawTests is PSMTestBase {
     }
 
     function test_withdraw_amountHigherThanUserShares() public {
-        _deposit(address(usdc), user1, 100e6);
-        _deposit(address(sDai), user1, 100e18);
-        _deposit(address(usdc), user2, 200e6);
+        _deposit(address(usdc),  user1, 100e6);
+        _deposit(address(susds), user1, 100e18);
+        _deposit(address(usdc),  user2, 200e6);
 
         assertEq(usdc.balanceOf(user2),        0);
         assertEq(usdc.balanceOf(receiver2),    0);
@@ -233,12 +233,12 @@ contract PSMWithdrawTests is PSMTestBase {
         // Zero amounts revert
         depositAmount1 = _bound(depositAmount1, 1, USDC_TOKEN_MAX);
         depositAmount2 = _bound(depositAmount2, 1, USDC_TOKEN_MAX);
-        depositAmount3 = _bound(depositAmount3, 1, SDAI_TOKEN_MAX);
+        depositAmount3 = _bound(depositAmount3, 1, SUSDS_TOKEN_MAX);
 
         // Zero amounts revert
         withdrawAmount1 = _bound(withdrawAmount1, 1, USDC_TOKEN_MAX);
         withdrawAmount2 = _bound(withdrawAmount2, 1, depositAmount2);  // User can't burn up to 1e12 shares for 0 USDC in this case
-        withdrawAmount3 = _bound(withdrawAmount3, 1, SDAI_TOKEN_MAX);
+        withdrawAmount3 = _bound(withdrawAmount3, 1, SUSDS_TOKEN_MAX);
 
         // Run with zero share tolerance because the rounding error shouldn't be introduced with the above constraints.
         _runWithdrawFuzzTests(
@@ -265,12 +265,12 @@ contract PSMWithdrawTests is PSMTestBase {
         // Zero amounts revert
         depositAmount1 = _bound(depositAmount1, 1, USDC_TOKEN_MAX);
         depositAmount2 = _bound(depositAmount2, 1, USDC_TOKEN_MAX);
-        depositAmount3 = _bound(depositAmount3, 1, SDAI_TOKEN_MAX);
+        depositAmount3 = _bound(depositAmount3, 1, SUSDS_TOKEN_MAX);
 
         // Zero amounts revert
         withdrawAmount1 = _bound(withdrawAmount1, 1, USDC_TOKEN_MAX);
         withdrawAmount2 = _bound(withdrawAmount2, 1, USDC_TOKEN_MAX);
-        withdrawAmount3 = _bound(withdrawAmount3, 1, SDAI_TOKEN_MAX);
+        withdrawAmount3 = _bound(withdrawAmount3, 1, SUSDS_TOKEN_MAX);
 
         // Run with 1e12 share tolerance because the rounding error will be introduced with the above constraints.
         _runWithdrawFuzzTests(
@@ -306,9 +306,9 @@ contract PSMWithdrawTests is PSMTestBase {
     )
         internal
     {
-        _deposit(address(usdc), user1, depositAmount1);
-        _deposit(address(usdc), user2, depositAmount2);
-        _deposit(address(sDai), user2, depositAmount3);
+        _deposit(address(usdc),  user1, depositAmount1);
+        _deposit(address(usdc),  user2, depositAmount2);
+        _deposit(address(susds), user2, depositAmount3);
 
         WithdrawFuzzTestVars memory vars;
 
@@ -337,7 +337,7 @@ contract PSMWithdrawTests is PSMTestBase {
         );
 
         // NOTE: User 1 doesn't need a tolerance because their shares are 1e6 precision because they only
-        //       deposited USDC. User 2 has a tolerance because they deposited sDAI which has 1e18 precision
+        //       deposited USDC. User 2 has a tolerance because they deposited sUSDS which has 1e18 precision
         //       so there is a chance that the rounding will be off by up to 1e12.
         assertEq(usdc.balanceOf(user1),        0);
         assertEq(usdc.balanceOf(receiver1),    vars.expectedWithdrawnAmount1);
@@ -346,7 +346,7 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(usdc.balanceOf(address(psm)), vars.totalUsdc - vars.expectedWithdrawnAmount1);
 
         assertEq(psm.shares(user1), (depositAmount1 - vars.expectedWithdrawnAmount1) * 1e12);
-        assertEq(psm.shares(user2), depositAmount2 * 1e12 + depositAmount3 * 125/100);  // Includes sDAI deposit
+        assertEq(psm.shares(user2), depositAmount2 * 1e12 + depositAmount3 * 125/100);  // Includes sUSDS deposit
         assertEq(psm.totalShares(), vars.totalValue - vars.expectedWithdrawnAmount1 * 1e12);
 
         vars.expectedWithdrawnAmount2 = _getExpectedWithdrawnAmount(usdc, user2, withdrawAmount2);
@@ -369,9 +369,9 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(usdc.balanceOf(receiver2),    vars.expectedWithdrawnAmount2);
         assertEq(usdc.balanceOf(address(psm)), vars.totalUsdc - (vars.expectedWithdrawnAmount1 + vars.expectedWithdrawnAmount2));
 
-        assertEq(sDai.balanceOf(user2),        0);
-        assertEq(sDai.balanceOf(receiver2),    0);
-        assertEq(sDai.balanceOf(address(psm)), depositAmount3);
+        assertEq(susds.balanceOf(user2),        0);
+        assertEq(susds.balanceOf(receiver2),    0);
+        assertEq(susds.balanceOf(address(psm)), depositAmount3);
 
         assertEq(psm.shares(user1), (depositAmount1 - vars.expectedWithdrawnAmount1) * 1e12);
 
@@ -387,10 +387,10 @@ contract PSMWithdrawTests is PSMTestBase {
             usdcShareTolerance
         );
 
-        vars.expectedWithdrawnAmount3 = _getExpectedWithdrawnAmount(sDai, user2, withdrawAmount3);
+        vars.expectedWithdrawnAmount3 = _getExpectedWithdrawnAmount(susds, user2, withdrawAmount3);
 
         vm.prank(user2);
-        amount = psm.withdraw(address(sDai), receiver2, withdrawAmount3);
+        amount = psm.withdraw(address(susds), receiver2, withdrawAmount3);
 
         assertApproxEqAbs(amount, vars.expectedWithdrawnAmount3, 1);
 
@@ -398,7 +398,7 @@ contract PSMWithdrawTests is PSMTestBase {
 
         assertApproxEqAbs(
             (usdc.balanceOf(receiver1) + usdc.balanceOf(receiver2)) * 1e12
-                + (sDai.balanceOf(receiver2) * rateProvider.getConversionRate() / 1e27)
+                + (susds.balanceOf(receiver2) * rateProvider.getConversionRate() / 1e27)
                 + psm.totalAssets(),
             vars.totalValue,
             1
@@ -410,34 +410,34 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(usdc.balanceOf(receiver2),    vars.expectedWithdrawnAmount2);
         assertEq(usdc.balanceOf(address(psm)), vars.totalUsdc - (vars.expectedWithdrawnAmount1 + vars.expectedWithdrawnAmount2));
 
-        assertApproxEqAbs(sDai.balanceOf(user2),        0,                                         0);
-        assertApproxEqAbs(sDai.balanceOf(receiver2),    vars.expectedWithdrawnAmount3,                  1);
-        assertApproxEqAbs(sDai.balanceOf(address(psm)), depositAmount3 - vars.expectedWithdrawnAmount3, 1);
+        assertApproxEqAbs(susds.balanceOf(user2),        0,                                              0);
+        assertApproxEqAbs(susds.balanceOf(receiver2),    vars.expectedWithdrawnAmount3,                  1);
+        assertApproxEqAbs(susds.balanceOf(address(psm)), depositAmount3 - vars.expectedWithdrawnAmount3, 1);
 
         assertEq(psm.shares(user1), (depositAmount1 - vars.expectedWithdrawnAmount1) * 1e12);
 
         assertApproxEqAbs(
             ((depositAmount2 * 1e12) + (depositAmount3 * 125/100) - (vars.expectedWithdrawnAmount2 * 1e12) - (vars.expectedWithdrawnAmount3 * 125/100)) - psm.shares(user2),
             0,
-            usdcShareTolerance + 1  // 1 is added to the tolerance because of rounding error in sDAI calculations
+            usdcShareTolerance + 1  // 1 is added to the tolerance because of rounding error in sUSDS calculations
         );
 
         assertApproxEqAbs(
             vars.totalValue - (vars.expectedWithdrawnAmount1 + vars.expectedWithdrawnAmount2) * 1e12 - (vars.expectedWithdrawnAmount3 * 125/100) - psm.totalShares(),
             0,
-            usdcShareTolerance + 1  // 1 is added to the tolerance because of rounding error in sDAI calculations
+            usdcShareTolerance + 1  // 1 is added to the tolerance because of rounding error in sUSDS calculations
         );
     }
 
     function test_withdraw_changeConversionRate() public {
         _deposit(address(usdc), user1, 100e6);
-        _deposit(address(sDai), user2, 100e18);
+        _deposit(address(susds), user2, 100e18);
 
         assertEq(psm.convertToShares(1e18), 1e18);
 
         mockRateProvider.__setConversionRate(1.5e27);
 
-        // Total shares / (100 USDC + 150 sDAI value)
+        // Total shares / (100 USDC + 150 sUSDS value)
         uint256 expectedConversionRate = 225 * 1e18 / 250;
 
         assertEq(expectedConversionRate, 0.9e18);
@@ -460,45 +460,45 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(usdc.balanceOf(user1),        100e6);
         assertEq(usdc.balanceOf(address(psm)), 0);
 
-        assertEq(sDai.balanceOf(user1),        0);
-        assertEq(sDai.balanceOf(user2),        0);
-        assertEq(sDai.balanceOf(address(psm)), 100e18);
+        assertEq(susds.balanceOf(user1),        0);
+        assertEq(susds.balanceOf(user2),        0);
+        assertEq(susds.balanceOf(address(psm)), 100e18);
 
         assertEq(psm.totalShares(), 135e18);
         assertEq(psm.shares(user1), 10e18);  // Burn 90 shares to get 100 USDC
         assertEq(psm.shares(user2), 125e18);
 
         vm.prank(user1);
-        amount = psm.withdraw(address(sDai), user1, type(uint256).max);
+        amount = psm.withdraw(address(susds), user1, type(uint256).max);
 
         uint256 user1SDai = uint256(10e18) * 1e18 / 0.9e18 * 1e27 / 1.5e27;
 
         assertEq(amount,    user1SDai);
         assertEq(user1SDai, 7.407407407407407407e18);
 
-        assertEq(sDai.balanceOf(user1),        user1SDai);
-        assertEq(sDai.balanceOf(user2),        0);
-        assertEq(sDai.balanceOf(address(psm)), 100e18 - user1SDai);
+        assertEq(susds.balanceOf(user1),        user1SDai);
+        assertEq(susds.balanceOf(user2),        0);
+        assertEq(susds.balanceOf(address(psm)), 100e18 - user1SDai);
 
         assertEq(psm.totalShares(), 125e18);
         assertEq(psm.shares(user1), 0);
         assertEq(psm.shares(user2), 125e18);
 
         vm.prank(user2);
-        amount = psm.withdraw(address(sDai), user2, type(uint256).max);
+        amount = psm.withdraw(address(susds), user2, type(uint256).max);
 
         assertEq(amount, 100e18 - user1SDai - 1);  // Remaining funds in PSM (rounding)
 
-        assertEq(sDai.balanceOf(user1),        user1SDai);
-        assertEq(sDai.balanceOf(user2),        100e18 - user1SDai - 1);  // Rounding
-        assertEq(sDai.balanceOf(address(psm)), 1);                       // Rounding
+        assertEq(susds.balanceOf(user1),        user1SDai);
+        assertEq(susds.balanceOf(user2),        100e18 - user1SDai - 1);  // Rounding
+        assertEq(susds.balanceOf(address(psm)), 1);                       // Rounding
 
         assertEq(psm.totalShares(), 0);
         assertEq(psm.shares(user1), 0);
         assertEq(psm.shares(user2), 0);
 
-        uint256 user1ResultingValue = usdc.balanceOf(user1) * 1e12 + sDai.balanceOf(user1) * 150/100;
-        uint256 user2ResultingValue = sDai.balanceOf(user2) * 150/100;  // Use 1.5 conversion rate
+        uint256 user1ResultingValue = usdc.balanceOf(user1) * 1e12 + susds.balanceOf(user1) * 150/100;
+        uint256 user2ResultingValue = susds.balanceOf(user2) * 150/100;  // Use 1.5 conversion rate
 
         assertEq(user1ResultingValue, 111.111111111111111110e18);
         assertEq(user2ResultingValue, 138.888888888888888888e18);
@@ -512,7 +512,7 @@ contract PSMWithdrawTests is PSMTestBase {
 
     function testFuzz_withdraw_changeConversionRate(
         uint256 usdcAmount,
-        uint256 sDaiAmount,
+        uint256 susdsAmount,
         uint256 conversionRate
     )
         public
@@ -522,18 +522,18 @@ contract PSMWithdrawTests is PSMTestBase {
         // Since rounding is against user if it stays the same the value can decrease and
         // the check will underflow
         usdcAmount     = _bound(usdcAmount,     1e6,     USDC_TOKEN_MAX);
-        sDaiAmount     = _bound(sDaiAmount,     1e18,    SDAI_TOKEN_MAX);
+        susdsAmount    = _bound(susdsAmount,    1e18,    SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 1.26e27, 1000e27);
 
         _deposit(address(usdc), user1, usdcAmount);
-        _deposit(address(sDai), user2, sDaiAmount);
+        _deposit(address(susds), user2, susdsAmount);
 
         mockRateProvider.__setConversionRate(conversionRate);
 
         uint256 user1Shares = usdcAmount * 1e12;
-        uint256 user2Shares = sDaiAmount * 125/100;
+        uint256 user2Shares = susdsAmount * 125/100;
         uint256 totalShares = user1Shares + user2Shares;
-        uint256 totalValue  = usdcAmount * 1e12 + sDaiAmount * conversionRate / 1e27;
+        uint256 totalValue  = usdcAmount * 1e12 + susdsAmount * conversionRate / 1e27;
 
         assertEq(psm.totalAssets(), totalValue);
 
@@ -553,9 +553,9 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(usdc.balanceOf(user1),        usdcAmount);
         assertEq(usdc.balanceOf(address(psm)), 0);
 
-        assertEq(sDai.balanceOf(user1),        0);
-        assertEq(sDai.balanceOf(user2),        0);
-        assertEq(sDai.balanceOf(address(psm)), sDaiAmount);
+        assertEq(susds.balanceOf(user1),        0);
+        assertEq(susds.balanceOf(user2),        0);
+        assertEq(susds.balanceOf(address(psm)), susdsAmount);
 
         uint256 expectedUser1SharesBurned = usdcAmount * 1e12 * totalShares / totalValue;
 
@@ -564,7 +564,7 @@ contract PSMWithdrawTests is PSMTestBase {
         assertApproxEqAbs(psm.shares(user2), user2Shares,                             0);
 
         vm.prank(user1);
-        amount = psm.withdraw(address(sDai), user1, type(uint256).max);
+        amount = psm.withdraw(address(susds), user1, type(uint256).max);
 
         {
             // User1s remaining shares are used
@@ -574,18 +574,18 @@ contract PSMWithdrawTests is PSMTestBase {
                 * 1e27
                 / conversionRate;
 
-            assertApproxEqAbs(sDai.balanceOf(user1),        user1SDai,              2);
-            assertApproxEqAbs(sDai.balanceOf(user2),        0,                      0);
-            assertApproxEqAbs(sDai.balanceOf(address(psm)), sDaiAmount - user1SDai, 2);
+            assertApproxEqAbs(susds.balanceOf(user1),        user1SDai,               2);
+            assertApproxEqAbs(susds.balanceOf(user2),        0,                       0);
+            assertApproxEqAbs(susds.balanceOf(address(psm)), susdsAmount - user1SDai, 2);
 
             vm.prank(user2);
-            amount = psm.withdraw(address(sDai), user2, type(uint256).max);
+            amount = psm.withdraw(address(susds), user2, type(uint256).max);
 
-            assertApproxEqAbs(amount, sDaiAmount - user1SDai, 2);
+            assertApproxEqAbs(amount, susdsAmount - user1SDai, 2);
 
-            assertApproxEqAbs(sDai.balanceOf(user1),        user1SDai,              2);
-            assertApproxEqAbs(sDai.balanceOf(user2),        sDaiAmount - user1SDai, 2);
-            assertApproxEqAbs(sDai.balanceOf(address(psm)), 0,                      2);
+            assertApproxEqAbs(susds.balanceOf(user1),        user1SDai,               2);
+            assertApproxEqAbs(susds.balanceOf(user2),        susdsAmount - user1SDai, 2);
+            assertApproxEqAbs(susds.balanceOf(address(psm)), 0,                       2);
         }
 
         assertEq(psm.totalShares(), 0);
@@ -593,9 +593,9 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(psm.shares(user2), 0);
 
         uint256 user1ResultingValue
-            = usdc.balanceOf(user1) * 1e12 + sDai.balanceOf(user1) * conversionRate / 1e27;
+            = usdc.balanceOf(user1) * 1e12 + susds.balanceOf(user1) * conversionRate / 1e27;
 
-        uint256 user2ResultingValue = sDai.balanceOf(user2) * conversionRate / 1e27;  // Use 1.5 conversion rate
+        uint256 user2ResultingValue = susds.balanceOf(user2) * conversionRate / 1e27;  // Use 1.5 conversion rate
 
         assertLe(psm.totalAssets(), 1000);
 
@@ -605,7 +605,7 @@ contract PSMWithdrawTests is PSMTestBase {
         // Value gains are the same for both users, accurate to 0.02%
         assertApproxEqRel(
             (user1ResultingValue - (usdcAmount * 1e12))    * 1e18 / (usdcAmount * 1e12),
-            (user2ResultingValue - (sDaiAmount * 125/100)) * 1e18 / (sDaiAmount * 125/100),
+            (user2ResultingValue - (susdsAmount * 125/100)) * 1e18 / (susdsAmount * 125/100),
             0.0021e18
         );
     }
@@ -617,7 +617,7 @@ contract PSMWithdrawTests is PSMTestBase {
     function _checkPsmInvariant() internal view {
         uint256 totalSharesValue = psm.convertToAssetValue(psm.totalShares());
         uint256 totalAssetsValue =
-            sDai.balanceOf(address(psm)) * rateProvider.getConversionRate() / 1e27
+            susds.balanceOf(address(psm)) * rateProvider.getConversionRate() / 1e27
             + usdc.balanceOf(address(psm)) * 1e12;
 
         assertApproxEqAbs(totalSharesValue, totalAssetsValue, 1);

--- a/test/unit/Withdraw.t.sol
+++ b/test/unit/Withdraw.t.sol
@@ -23,7 +23,7 @@ contract PSMWithdrawTests is PSMTestBase {
         psm.withdraw(address(usdc), receiver1, 0);
     }
 
-    function test_withdraw_notAsset0OrAsset1() public {
+    function test_withdraw_notUsdcOrUsds() public {
         vm.expectRevert("PSM3/invalid-asset");
         psm.withdraw(makeAddr("new-asset"), receiver1, 100e6);
     }

--- a/test/unit/Withdraw.t.sol
+++ b/test/unit/Withdraw.t.sol
@@ -28,7 +28,7 @@ contract PSMWithdrawTests is PSMTestBase {
         psm.withdraw(makeAddr("new-asset"), receiver1, 100e6);
     }
 
-    function test_withdraw_onlyDaiInPsm() public {
+    function test_withdraw_onlyUsdsInPsm() public {
         _deposit(address(usds), user1, 100e18);
 
         assertEq(usds.balanceOf(user1),        0);
@@ -82,7 +82,7 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(psm.convertToShares(1e18), 1e18);
     }
 
-    function test_withdraw_onlySDaiInPsm() public {
+    function test_withdraw_onlySUsdsInPsm() public {
         _deposit(address(susds), user1, 80e18);
 
         assertEq(susds.balanceOf(user1),        0);
@@ -109,7 +109,7 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(psm.convertToShares(1e18), 1e18);
     }
 
-    function test_withdraw_usdcThenSDai() public {
+    function test_withdraw_usdcThenSUsds() public {
         _deposit(address(usdc), user1, 100e6);
         _deposit(address(susds), user1, 100e18);
 
@@ -471,14 +471,14 @@ contract PSMWithdrawTests is PSMTestBase {
         vm.prank(user1);
         amount = psm.withdraw(address(susds), user1, type(uint256).max);
 
-        uint256 user1SDai = uint256(10e18) * 1e18 / 0.9e18 * 1e27 / 1.5e27;
+        uint256 user1SUsds = uint256(10e18) * 1e18 / 0.9e18 * 1e27 / 1.5e27;
 
-        assertEq(amount,    user1SDai);
-        assertEq(user1SDai, 7.407407407407407407e18);
+        assertEq(amount,     user1SUsds);
+        assertEq(user1SUsds, 7.407407407407407407e18);
 
-        assertEq(susds.balanceOf(user1),        user1SDai);
+        assertEq(susds.balanceOf(user1),        user1SUsds);
         assertEq(susds.balanceOf(user2),        0);
-        assertEq(susds.balanceOf(address(psm)), 100e18 - user1SDai);
+        assertEq(susds.balanceOf(address(psm)), 100e18 - user1SUsds);
 
         assertEq(psm.totalShares(), 125e18);
         assertEq(psm.shares(user1), 0);
@@ -487,10 +487,10 @@ contract PSMWithdrawTests is PSMTestBase {
         vm.prank(user2);
         amount = psm.withdraw(address(susds), user2, type(uint256).max);
 
-        assertEq(amount, 100e18 - user1SDai - 1);  // Remaining funds in PSM (rounding)
+        assertEq(amount, 100e18 - user1SUsds - 1);  // Remaining funds in PSM (rounding)
 
-        assertEq(susds.balanceOf(user1),        user1SDai);
-        assertEq(susds.balanceOf(user2),        100e18 - user1SDai - 1);  // Rounding
+        assertEq(susds.balanceOf(user1),        user1SUsds);
+        assertEq(susds.balanceOf(user2),        100e18 - user1SUsds - 1);  // Rounding
         assertEq(susds.balanceOf(address(psm)), 1);                       // Rounding
 
         assertEq(psm.totalShares(), 0);
@@ -568,24 +568,24 @@ contract PSMWithdrawTests is PSMTestBase {
 
         {
             // User1s remaining shares are used
-            uint256 user1SDai = (user1Shares - expectedUser1SharesBurned)
+            uint256 user1SUsds = (user1Shares - expectedUser1SharesBurned)
                 * totalValue
                 / totalShares
                 * 1e27
                 / conversionRate;
 
-            assertApproxEqAbs(susds.balanceOf(user1),        user1SDai,               2);
-            assertApproxEqAbs(susds.balanceOf(user2),        0,                       0);
-            assertApproxEqAbs(susds.balanceOf(address(psm)), susdsAmount - user1SDai, 2);
+            assertApproxEqAbs(susds.balanceOf(user1),        user1SUsds,               2);
+            assertApproxEqAbs(susds.balanceOf(user2),        0,                        0);
+            assertApproxEqAbs(susds.balanceOf(address(psm)), susdsAmount - user1SUsds, 2);
 
             vm.prank(user2);
             amount = psm.withdraw(address(susds), user2, type(uint256).max);
 
-            assertApproxEqAbs(amount, susdsAmount - user1SDai, 2);
+            assertApproxEqAbs(amount, susdsAmount - user1SUsds, 2);
 
-            assertApproxEqAbs(susds.balanceOf(user1),        user1SDai,               2);
-            assertApproxEqAbs(susds.balanceOf(user2),        susdsAmount - user1SDai, 2);
-            assertApproxEqAbs(susds.balanceOf(address(psm)), 0,                       2);
+            assertApproxEqAbs(susds.balanceOf(user1),        user1SUsds,               2);
+            assertApproxEqAbs(susds.balanceOf(user2),        susdsAmount - user1SUsds, 2);
+            assertApproxEqAbs(susds.balanceOf(address(psm)), 0,                        2);
         }
 
         assertEq(psm.totalShares(), 0);

--- a/test/unit/harnesses/PSM3Harness.sol
+++ b/test/unit/harnesses/PSM3Harness.sol
@@ -6,13 +6,13 @@ import { PSM3 } from "src/PSM3.sol";
 contract PSM3Harness is PSM3 {
 
     constructor(
-        address admin_,
+        address owner_,
         address asset0_,
         address asset1_,
         address asset2_,
         address rateProvider_
     )
-        PSM3(admin_, asset0_, asset1_, asset2_, rateProvider_) {}
+        PSM3(owner_, asset0_, asset1_, asset2_, rateProvider_) {}
 
     function getAssetValue(address asset, uint256 amount, bool roundUp)
         external view returns (uint256)

--- a/test/unit/harnesses/PSM3Harness.sol
+++ b/test/unit/harnesses/PSM3Harness.sol
@@ -7,12 +7,12 @@ contract PSM3Harness is PSM3 {
 
     constructor(
         address owner_,
-        address asset0_,
-        address asset1_,
-        address asset2_,
+        address usdc_,
+        address usds_,
+        address susds_,
         address rateProvider_
     )
-        PSM3(owner_, asset0_, asset1_, asset2_, rateProvider_) {}
+        PSM3(owner_, usdc_, usds_, susds_, rateProvider_) {}
 
     function getAssetValue(address asset, uint256 amount, bool roundUp)
         external view returns (uint256)
@@ -20,16 +20,16 @@ contract PSM3Harness is PSM3 {
         return _getAssetValue(asset, amount, roundUp);
     }
 
-    function getAsset0Value(uint256 amount) external view returns (uint256) {
-        return _getAsset0Value(amount);
+    function getUsdcValue(uint256 amount) external view returns (uint256) {
+        return _getUsdcValue(amount);
     }
 
-    function getAsset1Value(uint256 amount) external view returns (uint256) {
-        return _getAsset1Value(amount);
+    function getUsdsValue(uint256 amount) external view returns (uint256) {
+        return _getUsdsValue(amount);
     }
 
-    function getAsset2Value(uint256 amount, bool roundUp) external view returns (uint256) {
-        return _getAsset2Value(amount, roundUp);
+    function getSUsdsValue(uint256 amount, bool roundUp) external view returns (uint256) {
+        return _getSUsdsValue(amount, roundUp);
     }
 
 }

--- a/test/unit/harnesses/PSM3Harness.sol
+++ b/test/unit/harnesses/PSM3Harness.sol
@@ -5,8 +5,14 @@ import { PSM3 } from "src/PSM3.sol";
 
 contract PSM3Harness is PSM3 {
 
-    constructor(address asset0_, address asset1_, address asset2_, address rateProvider_)
-        PSM3(asset0_, asset1_, asset2_, rateProvider_) {}
+    constructor(
+        address admin_,
+        address asset0_,
+        address asset1_,
+        address asset2_,
+        address rateProvider_
+    )
+        PSM3(admin_, asset0_, asset1_, asset2_, rateProvider_) {}
 
     function getAssetValue(address asset, uint256 amount, bool roundUp)
         external view returns (uint256)


### PR DESCRIPTION
Add the same logic as the `dss-lite-psm` to use a `pocket` for coinbase custody to manage funds.

`setPocket` allows `owner` to set the `pocket`, transferring all funds to the new `pocket`. This is an extremely sensitive new piece of logic.

Also:
- Renamed `asset0`, `asset1`, and `asset2` to `usdc`, `usds`, and `susds` respectively
- Removed all dai naming in testing