### PR TITLE
feat: Add PSM pocket change (SC-724)

### DIFF
--- a/src/PSM3.sol
+++ b/src/PSM3.sol
@@ -409,7 +409,7 @@ contract PSM3 is IPSM3, Ownable {
     }
 
     function _pushAsset(address asset, address receiver, uint256 amount) internal {
-        if (asset == address(usdc)) {
+        if (asset == address(usdc) && pocket != address(this)) {
             usdc.safeTransferFrom(pocket, receiver, amount);
         } else {
             IERC20(asset).safeTransfer(receiver, amount);

--- a/src/PSM3.sol
+++ b/src/PSM3.sol
@@ -400,4 +400,8 @@ contract PSM3 is IPSM3, Ownable {
         return asset == address(usdc) || asset == address(usds) || asset == address(susds);
     }
 
+    function _getAssetCustodian(address asset) internal view returns (address custodian) {
+        custodian = asset == address(usdc) ? pocket : address(this);
+    }
+
 }

--- a/test/PSMTestBase.sol
+++ b/test/PSMTestBase.sol
@@ -54,6 +54,9 @@ contract PSMTestBase is Test {
         vm.prank(owner);
         psm.setPocket(pocket);
 
+        vm.prank(pocket);
+        usdc.approve(address(psm), type(uint256).max);
+
         vm.label(address(usds),  "USDS");
         vm.label(address(usdc),  "USDC");
         vm.label(address(susds), "sUSDS");
@@ -61,7 +64,7 @@ contract PSMTestBase is Test {
 
     function _getPsmValue() internal view returns (uint256) {
         return (susds.balanceOf(address(psm)) * rateProvider.getConversionRate() / 1e27)
-            + usdc.balanceOf(address(psm)) * 1e12
+            + usdc.balanceOf(psm.pocket()) * 1e12
             + usds.balanceOf(address(psm));
     }
 

--- a/test/PSMTestBase.sol
+++ b/test/PSMTestBase.sol
@@ -13,12 +13,13 @@ import { MockRateProvider } from "test/mocks/MockRateProvider.sol";
 
 contract PSMTestBase is Test {
 
-    address public owner = makeAddr("owner");
+    address public owner  = makeAddr("owner");
+    address public pocket = makeAddr("pocket");
 
     PSM3 public psm;
 
-    MockERC20 public usds;
     MockERC20 public usdc;
+    MockERC20 public usds;
     MockERC20 public susds;
 
     IRateProviderLike public rateProvider;  // Can be overridden by ssrOracle using same interface
@@ -37,8 +38,8 @@ contract PSMTestBase is Test {
     uint256 public constant USDC_TOKEN_MAX  = 1e18;
 
     function setUp() public virtual {
-        usds  = new MockERC20("usds",  "usds",  18);
         usdc  = new MockERC20("usdc",  "usdc",  6);
+        usds  = new MockERC20("usds",  "usds",  18);
         susds = new MockERC20("susds", "susds", 18);
 
         mockRateProvider = new MockRateProvider();
@@ -49,6 +50,9 @@ contract PSMTestBase is Test {
         rateProvider = IRateProviderLike(address(mockRateProvider));
 
         psm = new PSM3(owner, address(usdc), address(usds), address(susds), address(rateProvider));
+
+        vm.prank(owner);
+        psm.setPocket(pocket);
 
         vm.label(address(usds),  "USDS");
         vm.label(address(usdc),  "USDC");

--- a/test/invariant/Invariants.t.sol
+++ b/test/invariant/Invariants.t.sol
@@ -361,10 +361,6 @@ contract PSMInvariants_ConstantRate_NoTransfer is PSMInvariantTestBase {
     function setUp() public override {
         super.setUp();
 
-        // Start with the PSM as the pocket so that funds can be transferred out
-        vm.prank(owner);
-        psm.setPocket(address(psm));
-
         lpHandler      = new LpHandler(psm, usdc, usds, susds, 3);
         swapperHandler = new SwapperHandler(psm, usdc, usds, susds, 3);
 
@@ -410,10 +406,6 @@ contract PSMInvariants_ConstantRate_WithTransfers is PSMInvariantTestBase {
     function setUp() public override {
         super.setUp();
 
-        // Start with the PSM as the pocket so that funds can be transferred out
-        vm.prank(owner);
-        psm.setPocket(address(psm));
-
         lpHandler       = new LpHandler(psm, usdc, usds, susds, 3);
         swapperHandler  = new SwapperHandler(psm, usdc, usds, susds, 3);
         transferHandler = new TransferHandler(psm, usdc, usds, susds);
@@ -456,10 +448,6 @@ contract PSMInvariants_RateSetting_NoTransfer is PSMInvariantTestBase {
 
     function setUp() public override {
         super.setUp();
-
-        // Start with the PSM as the pocket so that funds can be transferred out
-        vm.prank(owner);
-        psm.setPocket(address(psm));
 
         lpHandler         = new LpHandler(psm, usdc, usds, susds, 3);
         rateSetterHandler = new RateSetterHandler(psm, address(rateProvider), 1.25e27);
@@ -506,10 +494,6 @@ contract PSMInvariants_RateSetting_WithTransfers is PSMInvariantTestBase {
 
     function setUp() public override {
         super.setUp();
-
-        // Start with the PSM as the pocket so that funds can be transferred out
-        vm.prank(owner);
-        psm.setPocket(address(psm));
 
         lpHandler         = new LpHandler(psm, usdc, usds, susds, 3);
         rateSetterHandler = new RateSetterHandler(psm, address(rateProvider), 1.25e27);
@@ -655,7 +639,8 @@ contract PSMInvariants_TimeBasedRateSetting_WithTransfers is PSMInvariantTestBas
         // Redeploy PSM with new rate provider
         psm = new PSM3(owner, address(usdc), address(usds), address(susds), address(ssrOracle));
 
-        // NOTE: Don't need to set PSM as pocket for this suite as its default on deploy
+        // NOTE: This base test suite tests the case of the PSM being the pocket for the whole time,
+        //       where the other suites are testing with an external `pocket`.
 
         // Seed the new PSM with 1e18 shares (1e18 of value)
         _deposit(address(usds), BURN_ADDRESS, 1e18);
@@ -728,6 +713,9 @@ contract PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting is P
 
     function setUp() public override {
         super.setUp();
+
+        // NOTE: The PSM is the pocket to start, so the test suite will start with it as the pocket
+        //       and transfer it to other addresses.
 
         ownerHandler = new OwnerHandler(psm, usdc);
         targetContract(address(ownerHandler));

--- a/test/invariant/Invariants.t.sol
+++ b/test/invariant/Invariants.t.sol
@@ -129,7 +129,7 @@ abstract contract PSMInvariantTestBase is PSMTestBase {
             expectedSUsdsInflows += transferHandler.transfersIn(address(susds));
         }
 
-        assertEq(usdc.balanceOf(address(psm)),  expectedUsdcInflows  - expectedUsdcOutflows);
+        assertEq(usdc.balanceOf(psm.pocket()),  expectedUsdcInflows  - expectedUsdcOutflows);
         assertEq(usds.balanceOf(address(psm)),  expectedUsdsInflows  - expectedUsdsOutflows);
         assertEq(susds.balanceOf(address(psm)), expectedSUsdsInflows - expectedSUsdsOutflows);
     }
@@ -557,6 +557,12 @@ contract PSMInvariants_TimeBasedRateSetting_NoTransfer is PSMInvariantTestBase {
         // Redeploy PSM with new rate provider
         psm = new PSM3(owner, address(usdc), address(usds), address(susds), address(ssrOracle));
 
+        vm.prank(owner);
+        psm.setPocket(pocket);
+
+        vm.prank(pocket);
+        usdc.approve(address(psm), type(uint256).max);
+
         // Seed the new PSM with 1e18 shares (1e18 of value)
         _deposit(address(usds), BURN_ADDRESS, 1e18);
 
@@ -581,7 +587,7 @@ contract PSMInvariants_TimeBasedRateSetting_NoTransfer is PSMInvariantTestBase {
         assertEq(swapperHandler.lp0(), lpHandler.lps(0));
     }
 
-    function invariant_A() public view {
+    function invariant_A_test() public view {
         _checkInvariant_A();
     }
 
@@ -635,6 +641,12 @@ contract PSMInvariants_TimeBasedRateSetting_WithTransfers is PSMInvariantTestBas
 
         // Redeploy PSM with new rate provider
         psm = new PSM3(owner, address(usdc), address(usds), address(susds), address(ssrOracle));
+
+        vm.prank(owner);
+        psm.setPocket(pocket);
+
+        vm.prank(pocket);
+        usdc.approve(address(psm), type(uint256).max);
 
         // Seed the new PSM with 1e18 shares (1e18 of value)
         _deposit(address(usds), BURN_ADDRESS, 1e18);

--- a/test/invariant/handlers/OwnerHandler.sol
+++ b/test/invariant/handlers/OwnerHandler.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import { MockERC20 } from "erc20-helpers/MockERC20.sol";
+
+import { HandlerBase, PSM3 } from "test/invariant/handlers/HandlerBase.sol";
+
+contract OwnerHandler is HandlerBase {
+
+    MockERC20 public usdc;
+
+    constructor(PSM3 psm_, MockERC20 usdc_) HandlerBase(psm_) {
+        usdc = usdc_;
+    }
+
+    function setPocket(string memory salt) public {
+        address newPocket = makeAddr(salt);
+
+        // Avoid "same pocket" error
+        if (newPocket == psm.pocket()) {
+            newPocket = makeAddr(string(abi.encodePacked(salt, "salt")));
+        }
+
+        // Assumption is made that the pocket will always infinite approve the PSM
+        vm.prank(newPocket);
+        usdc.approve(address(psm), type(uint256).max);
+
+        uint256 oldPocketBalance   = usdc.balanceOf(psm.pocket());
+        uint256 newPocketBalance   = usdc.balanceOf(newPocket);
+        uint256 totalAssets        = psm.totalAssets();
+        uint256 startingConversion = psm.convertToAssetValue(1e18);
+
+        address oldPocket = psm.pocket();
+
+        psm.setPocket(newPocket);
+
+        // Old pocket should be cleared of USDC
+        assertEq(
+            usdc.balanceOf(oldPocket),
+            0,
+            "OwnerHandler/old-pocket-balance"
+        );
+
+        // New pocket should get full pocket balance
+        assertEq(
+            usdc.balanceOf(newPocket),
+            newPocketBalance + oldPocketBalance,
+            "OwnerHandler/new-pocket-balance"
+        );
+
+        // Total assets should be exactly the same
+        assertEq(
+            psm.totalAssets(),
+            totalAssets,
+            "OwnerHandler/total-assets"
+        );
+
+        // Conversion rate should be exactly the same
+        assertEq(
+            psm.convertToAssetValue(1e18),
+            startingConversion,
+            "OwnerHandler/starting-conversion"
+        );
+    }
+
+}

--- a/test/invariant/handlers/SwapperHandler.sol
+++ b/test/invariant/handlers/SwapperHandler.sol
@@ -80,12 +80,15 @@ contract SwapperHandler is HandlerBase {
             assetOut = _getAsset(assetOutSeed + 2);
         }
 
+        address assetOutCustodian
+            = address(assetOut) == address(assets[0]) ? psm.pocket() : address(psm);
+
         // By calculating the amount of assetIn we can get from the max asset out, we can
         // determine the max amount of assetIn we can swap since its the same both ways.
         uint256 maxAmountIn = psm.previewSwapExactIn(
             address(assetOut),
             address(assetIn),
-            assetOut.balanceOf(address(psm))
+            assetOut.balanceOf(assetOutCustodian)
         );
 
         // If there's zero balance a swap can't be performed
@@ -230,13 +233,16 @@ contract SwapperHandler is HandlerBase {
             assetOut = _getAsset(assetOutSeed + 2);
         }
 
+        address assetOutCustodian
+            = address(assetOut) == address(assets[0]) ? psm.pocket() : address(psm);
+
         // If there's zero balance a swap can't be performed
-        if (assetOut.balanceOf(address(psm)) == 0) {
+        if (assetOut.balanceOf(assetOutCustodian) == 0) {
             zeroBalanceCount++;
             return;
         }
 
-        amountOut = _bound(amountOut, 1, assetOut.balanceOf(address(psm)));
+        amountOut = _bound(amountOut, 1, assetOut.balanceOf(assetOutCustodian));
 
         // Not testing this functionality, just want a successful swap
         uint256 maxAmountIn = type(uint256).max;
@@ -358,7 +364,5 @@ contract SwapperHandler is HandlerBase {
         else if (asset == address(assets[2])) return amount * rateProvider.getConversionRate() / 1e27;
         else revert("SwapperHandler/asset-not-found");
     }
-
-    // TODO: Add swapExactOut in separate PR
 
 }

--- a/test/invariant/handlers/TransferHandler.sol
+++ b/test/invariant/handlers/TransferHandler.sol
@@ -44,10 +44,12 @@ contract TransferHandler is HandlerBase {
         // on transfer amounts.
         amount = _bound(amount, 1, 10_000_000 * 10 ** asset.decimals());
 
+        address custodian = address(asset) == address(assets[0]) ? psm.pocket() : address(psm);
+
         // 3. Perform action against protocol
         asset.mint(sender, amount);
         vm.prank(sender);
-        asset.transfer(address(psm), amount);
+        asset.transfer(custodian, amount);
 
         // 4. Update ghost variable(s)
         transfersIn[address(asset)] += amount;

--- a/test/unit/Deposit.t.sol
+++ b/test/unit/Deposit.t.sol
@@ -119,6 +119,41 @@ contract PSMDepositTests is PSMTestBase {
         assertEq(psm.convertToShares(1e18), 1e18);
     }
 
+    function test_deposit_firstDepositUsdc_pocketIsPsm() public {
+        vm.prank(owner);
+        psm.setPocket(address(psm));
+
+        usdc.mint(user1, 100e6);
+
+        vm.startPrank(user1);
+
+        usdc.approve(address(psm), 100e6);
+
+        assertEq(usdc.allowance(user1, address(psm)), 100e6);
+        assertEq(usdc.balanceOf(user1),               100e6);
+        assertEq(usdc.balanceOf(address(psm)),        0);
+
+        assertEq(psm.totalShares(),     0);
+        assertEq(psm.shares(user1),     0);
+        assertEq(psm.shares(receiver1), 0);
+
+        assertEq(psm.convertToShares(1e18), 1e18);
+
+        uint256 newShares = psm.deposit(address(usdc), receiver1, 100e6);
+
+        assertEq(newShares, 100e18);
+
+        assertEq(usdc.allowance(user1, address(psm)), 0);
+        assertEq(usdc.balanceOf(user1),               0);
+        assertEq(usdc.balanceOf(address(psm)),       100e6);
+
+        assertEq(psm.totalShares(),     100e18);
+        assertEq(psm.shares(user1),     0);
+        assertEq(psm.shares(receiver1), 100e18);
+
+        assertEq(psm.convertToShares(1e18), 1e18);
+    }
+
     function test_deposit_firstDepositSUsds() public {
         susds.mint(user1, 100e18);
 

--- a/test/unit/Deposit.t.sol
+++ b/test/unit/Deposit.t.sol
@@ -96,7 +96,7 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(usdc.allowance(user1, address(psm)), 100e6);
         assertEq(usdc.balanceOf(user1),               100e6);
-        assertEq(usdc.balanceOf(address(psm)),        0);
+        assertEq(usdc.balanceOf(pocket),              0);
 
         assertEq(psm.totalShares(),     0);
         assertEq(psm.shares(user1),     0);
@@ -110,7 +110,7 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(usdc.allowance(user1, address(psm)), 0);
         assertEq(usdc.balanceOf(user1),               0);
-        assertEq(usdc.balanceOf(address(psm)),        100e6);
+        assertEq(usdc.balanceOf(pocket),              100e6);
 
         assertEq(psm.totalShares(),     100e18);
         assertEq(psm.shares(user1),     0);
@@ -165,7 +165,7 @@ contract PSMDepositTests is PSMTestBase {
         susds.mint(user1, 100e18);
         susds.approve(address(psm), 100e18);
 
-        assertEq(usdc.balanceOf(address(psm)), 100e6);
+        assertEq(usdc.balanceOf(pocket), 100e6);
 
         assertEq(susds.allowance(user1, address(psm)), 100e18);
         assertEq(susds.balanceOf(user1),               100e18);
@@ -181,7 +181,7 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(newShares, 125e18);
 
-        assertEq(usdc.balanceOf(address(psm)), 100e6);
+        assertEq(usdc.balanceOf(pocket), 100e6);
 
         assertEq(susds.allowance(user1, address(psm)), 0);
         assertEq(susds.balanceOf(user1),               0);
@@ -212,7 +212,7 @@ contract PSMDepositTests is PSMTestBase {
         susds.mint(user1, susdsAmount);
         susds.approve(address(psm), susdsAmount);
 
-        assertEq(usdc.balanceOf(address(psm)), usdcAmount);
+        assertEq(usdc.balanceOf(pocket), usdcAmount);
 
         assertEq(susds.allowance(user1, address(psm)), susdsAmount);
         assertEq(susds.balanceOf(user1),               susdsAmount);
@@ -228,7 +228,7 @@ contract PSMDepositTests is PSMTestBase {
 
         assertEq(newShares, susdsAmount * 125/100);
 
-        assertEq(usdc.balanceOf(address(psm)), usdcAmount);
+        assertEq(usdc.balanceOf(pocket), usdcAmount);
 
         assertEq(susds.allowance(user1, address(psm)), 0);
         assertEq(susds.balanceOf(user1),               0);
@@ -261,7 +261,7 @@ contract PSMDepositTests is PSMTestBase {
 
         vm.stopPrank();
 
-        assertEq(usdc.balanceOf(address(psm)), 100e6);
+        assertEq(usdc.balanceOf(pocket), 100e6);
 
         assertEq(susds.allowance(user1, address(psm)), 0);
         assertEq(susds.balanceOf(user1),               0);
@@ -359,7 +359,7 @@ contract PSMDepositTests is PSMTestBase {
 
         vm.stopPrank();
 
-        assertEq(usdc.balanceOf(address(psm)), usdcAmount);
+        assertEq(usdc.balanceOf(pocket), usdcAmount);
 
         assertEq(susds.balanceOf(user1),        0);
         assertEq(susds.balanceOf(address(psm)), susdsAmount1);

--- a/test/unit/DoSAttack.t.sol
+++ b/test/unit/DoSAttack.t.sol
@@ -13,9 +13,9 @@ contract InflationAttackTests is PSMTestBase {
     function test_dos_sendFundsBeforeFirstDeposit() public {
         // Attack pool sending funds in before the first deposit
         usdc.mint(address(this), 100e6);
-        usdc.transfer(address(psm), 100e6);
+        usdc.transfer(pocket, 100e6);
 
-        assertEq(usdc.balanceOf(address(psm)), 100e6);
+        assertEq(usdc.balanceOf(pocket), 100e6);
 
         assertEq(psm.totalShares(), 0);
         assertEq(psm.shares(user1), 0);
@@ -27,7 +27,7 @@ contract InflationAttackTests is PSMTestBase {
         // because totalValue is not zero so it enters that if statement.
         // This results in the funds going in the pool with no way for the user
         // to recover them.
-        assertEq(usdc.balanceOf(address(psm)), 1_000_100e6);
+        assertEq(usdc.balanceOf(pocket), 1_000_100e6);
 
         assertEq(psm.totalShares(), 0);
         assertEq(psm.shares(user1), 0);
@@ -37,7 +37,7 @@ contract InflationAttackTests is PSMTestBase {
         // get above zero.
         _deposit(address(usdc), address(user2), 1_000_000e6);
 
-        assertEq(usdc.balanceOf(address(psm)), 2_000_100e6);
+        assertEq(usdc.balanceOf(pocket), 2_000_100e6);
 
         assertEq(psm.totalShares(), 0);
         assertEq(psm.shares(user1), 0);

--- a/test/unit/Events.t.sol
+++ b/test/unit/Events.t.sol
@@ -83,7 +83,7 @@ contract PSMEventTests is PSMTestBase {
 
     function test_swap_events() public {
         usds.mint(address(psm),  1000e18);
-        usdc.mint(address(psm), 1000e6);
+        usdc.mint(pocket, 1000e6);
         susds.mint(address(psm), 1000e18);
 
         vm.startPrank(sender);

--- a/test/unit/Getters.t.sol
+++ b/test/unit/Getters.t.sol
@@ -230,7 +230,7 @@ contract GetPsmTotalValueTests is PSMTestBase {
 
         assertEq(psm.totalAssets(), 1e18);
 
-        usdc.mint(address(psm), 1e6);
+        usdc.mint(address(pocket), 1e6);
 
         assertEq(psm.totalAssets(), 2e18);
 
@@ -242,7 +242,7 @@ contract GetPsmTotalValueTests is PSMTestBase {
 
         assertEq(psm.totalAssets(), 2.25e18);
 
-        usdc.burn(address(psm), 1e6);
+        usdc.burn(address(pocket), 1e6);
 
         assertEq(psm.totalAssets(), 1.25e18);
 
@@ -254,8 +254,8 @@ contract GetPsmTotalValueTests is PSMTestBase {
     function test_totalAssets_conversionRateChanges() public {
         assertEq(psm.totalAssets(), 0);
 
-        usds.mint(address(psm),  1e18);
-        usdc.mint(address(psm), 1e6);
+        usds.mint(address(psm), 1e18);
+        usdc.mint(address(pocket), 1e6);
         susds.mint(address(psm), 1e18);
 
         assertEq(psm.totalAssets(), 3.25e18);
@@ -272,8 +272,8 @@ contract GetPsmTotalValueTests is PSMTestBase {
     function test_totalAssets_bothChange() public {
         assertEq(psm.totalAssets(), 0);
 
-        usds.mint(address(psm),  1e18);
-        usdc.mint(address(psm), 1e6);
+        usds.mint(address(psm), 1e18);
+        usdc.mint(address(pocket), 1e6);
         susds.mint(address(psm), 1e18);
 
         assertEq(psm.totalAssets(), 3.25e18);
@@ -300,8 +300,8 @@ contract GetPsmTotalValueTests is PSMTestBase {
         susdsAmount    = _bound(susdsAmount,    0,         SUSDS_TOKEN_MAX);
         conversionRate = _bound(conversionRate, 0.0001e27, 1000e27);
 
-        usds.mint(address(psm),  usdsAmount);
-        usdc.mint(address(psm),  usdcAmount);
+        usds.mint(address(psm), usdsAmount);
+        usdc.mint(address(pocket), usdcAmount);
         susds.mint(address(psm), susdsAmount);
 
         mockRateProvider.__setConversionRate(conversionRate);

--- a/test/unit/Getters.t.sol
+++ b/test/unit/Getters.t.sol
@@ -20,6 +20,9 @@ contract PSMHarnessTests is PSMTestBase {
             address(susds),
             address(rateProvider)
         );
+
+        vm.prank(owner);
+        psmHarness.setPocket(pocket);
     }
 
     function test_getUsdsValue() public view {
@@ -210,6 +213,12 @@ contract PSMHarnessTests is PSMTestBase {
     function test_getAssetValue_zeroAddress() public {
         vm.expectRevert("PSM3/invalid-asset-for-value");
         psmHarness.getAssetValue(address(0), 1, false);
+    }
+
+    function test_getAssetCustodian() public view {
+        assertEq(psmHarness.getAssetCustodian(address(usdc)),  address(pocket));
+        assertEq(psmHarness.getAssetCustodian(address(usds)),  address(psmHarness));
+        assertEq(psmHarness.getAssetCustodian(address(susds)), address(psmHarness));
     }
 
 }

--- a/test/unit/InflationAttack.t.sol
+++ b/test/unit/InflationAttack.t.sol
@@ -61,7 +61,7 @@ contract InflationAttackTests is PSMTestBase {
         assertEq(psm.convertToAssetValue(1), 1);
 
         vm.prank(frontRunner);
-        usdc.transfer(address(psm), 10_000_000e6);
+        usdc.transfer(pocket, 10_000_000e6);
 
         // Highly inflated exchange rate
         assertEq(psm.convertToAssetValue(1), 10_000_000e18 + 1);
@@ -81,7 +81,7 @@ contract InflationAttackTests is PSMTestBase {
         _withdraw(address(usdc), firstDepositor, type(uint256).max);
         _withdraw(address(usdc), frontRunner,    type(uint256).max);
 
-        assertEq(usdc.balanceOf(address(psm)), 0);
+        assertEq(usdc.balanceOf(pocket), 0);
 
         // Front runner profits 5m USDC, first depositor loses 5m USDC
         assertEq(usdc.balanceOf(firstDepositor), 15_000_000e6);
@@ -98,7 +98,7 @@ contract InflationAttackTests is PSMTestBase {
         deal(address(usdc), frontRunner, 10_000_000e6);
 
         vm.prank(frontRunner);
-        usdc.transfer(address(psm), 10_000_000e6);
+        usdc.transfer(pocket, 10_000_000e6);
 
         // Still inflated, but all value is transferred to existing holder, deployer
         assertEq(psm.convertToAssetValue(1), 0.00000000001e18);

--- a/test/unit/SetPocket.t.sol
+++ b/test/unit/SetPocket.t.sol
@@ -22,7 +22,7 @@ contract PSMSetPocketFailureTests is PSMTestBase {
     function test_setPocket_samePocket() public {
         vm.prank(owner);
         vm.expectRevert("PSM3/same-pocket");
-        psm.setPocket(address(psm));
+        psm.setPocket(pocket);
     }
 
 
@@ -68,11 +68,11 @@ contract PSMSetPocketSuccessTests is PSMTestBase {
         assertEq(usdc.balanceOf(address(psm)), 1_000_000e6);
         assertEq(usdc.balanceOf(pocket1),      0);
 
-        assertEq(psm.pocket(), address(psm));
+        assertEq(psm.pocket(), pocket);
 
         vm.prank(owner);
         vm.expectEmit(address(psm));
-        emit PocketSet(address(psm), pocket1, 1_000_000e6);
+        emit PocketSet(pocket, pocket1, 1_000_000e6);
         psm.setPocket(pocket1);
 
         assertEq(usdc.balanceOf(address(psm)), 0);
@@ -95,6 +95,8 @@ contract PSMSetPocketSuccessTests is PSMTestBase {
         assertEq(usdc.balanceOf(pocket1), 1_000_000e6);
         assertEq(usdc.balanceOf(pocket2), 0);
 
+        assertEq(psm.totalAssets(), 0);
+
         assertEq(psm.pocket(), pocket1);
 
         vm.prank(owner);
@@ -107,7 +109,27 @@ contract PSMSetPocketSuccessTests is PSMTestBase {
         assertEq(usdc.balanceOf(pocket1), 0);
         assertEq(usdc.balanceOf(pocket2), 1_000_000e6);
 
+        assertEq(psm.totalAssets(), 0);
+
         assertEq(psm.pocket(), pocket2);
+    }
+
+    function test_setPocket_valueStaysConstant() public {
+        // NOTE: Need to set pocket to PSM because setUp sets pocket to `pocket`, and zero funds
+        //       are transferred from `pocket1` to `pocket`
+        vm.prank(owner);
+        psm.setPocket(address(psm));
+
+        _deposit(address(usdc),  owner, 1_000_000e6);
+        _deposit(address(usds),  owner, 1_000_000e18);
+        _deposit(address(susds), owner, 800_000e18);
+
+        assertEq(psm.totalAssets(), 3_000_000e18);
+
+        vm.prank(owner);
+        psm.setPocket(pocket1);
+
+        assertEq(psm.totalAssets(), 2_000_000e18);
     }
 
 }

--- a/test/unit/SetPocket.t.sol
+++ b/test/unit/SetPocket.t.sol
@@ -63,20 +63,27 @@ contract PSMSetPocketSuccessTests is PSMTestBase {
     );
 
     function test_setPocket_pocketIsPsm() public {
+        vm.prank(owner);
+        psm.setPocket(address(psm));
+
         deal(address(usdc), address(psm), 1_000_000e6);
 
         assertEq(usdc.balanceOf(address(psm)), 1_000_000e6);
         assertEq(usdc.balanceOf(pocket1),      0);
 
-        assertEq(psm.pocket(), pocket);
+        assertEq(psm.totalAssets(), 1_000_000e18);
+
+        assertEq(psm.pocket(), address(psm));
 
         vm.prank(owner);
         vm.expectEmit(address(psm));
-        emit PocketSet(pocket, pocket1, 1_000_000e6);
+        emit PocketSet(address(psm), pocket1, 1_000_000e6);
         psm.setPocket(pocket1);
 
         assertEq(usdc.balanceOf(address(psm)), 0);
         assertEq(usdc.balanceOf(pocket1),      1_000_000e6);
+
+        assertEq(psm.totalAssets(), 1_000_000e18);
 
         assertEq(psm.pocket(), pocket1);
     }
@@ -95,7 +102,7 @@ contract PSMSetPocketSuccessTests is PSMTestBase {
         assertEq(usdc.balanceOf(pocket1), 1_000_000e6);
         assertEq(usdc.balanceOf(pocket2), 0);
 
-        assertEq(psm.totalAssets(), 0);
+        assertEq(psm.totalAssets(), 1_000_000e18);
 
         assertEq(psm.pocket(), pocket1);
 
@@ -109,7 +116,7 @@ contract PSMSetPocketSuccessTests is PSMTestBase {
         assertEq(usdc.balanceOf(pocket1), 0);
         assertEq(usdc.balanceOf(pocket2), 1_000_000e6);
 
-        assertEq(psm.totalAssets(), 0);
+        assertEq(psm.totalAssets(), 1_000_000e18);
 
         assertEq(psm.pocket(), pocket2);
     }
@@ -129,7 +136,7 @@ contract PSMSetPocketSuccessTests is PSMTestBase {
         vm.prank(owner);
         psm.setPocket(pocket1);
 
-        assertEq(psm.totalAssets(), 2_000_000e18);
+        assertEq(psm.totalAssets(), 3_000_000e18);
     }
 
 }

--- a/test/unit/SwapExactIn.t.sol
+++ b/test/unit/SwapExactIn.t.sol
@@ -16,7 +16,7 @@ contract PSMSwapExactInFailureTests is PSMTestBase {
         super.setUp();
 
         // Needed for boundary success conditions
-        usdc.mint(address(psm), 100e6);
+        usdc.mint(pocket, 100e6);
         susds.mint(address(psm), 100e18);
     }
 
@@ -135,7 +135,7 @@ contract PSMSwapExactInSuccessTestsBase is PSMTestBase {
         // Mint 100x higher than max amount for each token (max conversion rate)
         // Covers both lower and upper bounds of conversion rate (1% to 10,000% are both 100x)
         usds.mint(address(psm),  USDS_TOKEN_MAX  * 100);
-        usdc.mint(address(psm),  USDC_TOKEN_MAX  * 100);
+        usdc.mint(pocket,        USDC_TOKEN_MAX  * 100);
         susds.mint(address(psm), SUSDS_TOKEN_MAX * 100);
     }
 
@@ -151,6 +151,9 @@ contract PSMSwapExactInSuccessTestsBase is PSMTestBase {
         uint256 psmAssetInBalance  = 100_000_000_000_000 * 10 ** assetIn.decimals();
         uint256 psmAssetOutBalance = 100_000_000_000_000 * 10 ** assetOut.decimals();
 
+        address assetInCustodian  = address(assetIn)  == address(usdc) ? pocket : address(psm);
+        address assetOutCustodian = address(assetOut) == address(usdc) ? pocket : address(psm);
+
         assetIn.mint(swapper_, amountIn);
 
         vm.startPrank(swapper_);
@@ -159,11 +162,11 @@ contract PSMSwapExactInSuccessTestsBase is PSMTestBase {
 
         assertEq(assetIn.allowance(swapper_, address(psm)), amountIn);
 
-        assertEq(assetIn.balanceOf(swapper_),     amountIn);
-        assertEq(assetIn.balanceOf(address(psm)), psmAssetInBalance);
+        assertEq(assetIn.balanceOf(swapper_),         amountIn);
+        assertEq(assetIn.balanceOf(assetInCustodian), psmAssetInBalance);
 
-        assertEq(assetOut.balanceOf(receiver_),    0);
-        assertEq(assetOut.balanceOf(address(psm)), psmAssetOutBalance);
+        assertEq(assetOut.balanceOf(receiver_),         0);
+        assertEq(assetOut.balanceOf(assetOutCustodian), psmAssetOutBalance);
 
         uint256 returnedAmountOut = psm.swapExactIn(
             address(assetIn),
@@ -178,11 +181,11 @@ contract PSMSwapExactInSuccessTestsBase is PSMTestBase {
 
         assertEq(assetIn.allowance(swapper_, address(psm)), 0);
 
-        assertEq(assetIn.balanceOf(swapper_),     0);
-        assertEq(assetIn.balanceOf(address(psm)), psmAssetInBalance + amountIn);
+        assertEq(assetIn.balanceOf(swapper_),         0);
+        assertEq(assetIn.balanceOf(assetInCustodian), psmAssetInBalance + amountIn);
 
-        assertEq(assetOut.balanceOf(receiver_),    amountOut);
-        assertEq(assetOut.balanceOf(address(psm)), psmAssetOutBalance - amountOut);
+        assertEq(assetOut.balanceOf(receiver_),         amountOut);
+        assertEq(assetOut.balanceOf(assetOutCustodian), psmAssetOutBalance - amountOut);
     }
 
 }
@@ -211,7 +214,9 @@ contract PSMSwapExactInUsdsAssetInTests is PSMSwapExactInSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountIn = _bound(amountIn, 1, USDS_TOKEN_MAX);  // Zero amount reverts
@@ -226,7 +231,9 @@ contract PSMSwapExactInUsdsAssetInTests is PSMSwapExactInSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountIn       = _bound(amountIn,       1,       USDS_TOKEN_MAX);
@@ -264,7 +271,9 @@ contract PSMSwapExactInUsdcAssetInTests is PSMSwapExactInSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountIn = _bound(amountIn, 1, USDC_TOKEN_MAX);  // Zero amount reverts
@@ -279,7 +288,9 @@ contract PSMSwapExactInUsdcAssetInTests is PSMSwapExactInSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountIn       = _bound(amountIn,       1,       USDC_TOKEN_MAX);
@@ -319,7 +330,9 @@ contract PSMSwapExactInSUsdsAssetInTests is PSMSwapExactInSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountIn       = _bound(amountIn,       1,       SUSDS_TOKEN_MAX);
@@ -339,7 +352,9 @@ contract PSMSwapExactInSUsdsAssetInTests is PSMSwapExactInSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountIn       = _bound(amountIn,       1,       SUSDS_TOKEN_MAX);
@@ -409,11 +424,13 @@ contract PSMSwapExactInFuzzTests is PSMTestBase {
                 assetOut = _getAsset(_hash(i, "assetOut") + 1);
             }
 
+            address assetOutCustodian = address(assetOut) == address(usdc) ? pocket : address(psm);
+
             // Calculate the maximum amount that can be swapped by using the inverse conversion rate
             uint256 maxAmountIn = psm.previewSwapExactOut(
                 address(assetIn),
                 address(assetOut),
-                assetOut.balanceOf(address(psm))
+                assetOut.balanceOf(assetOutCustodian)
             );
 
             uint256 amountIn = _bound(_hash(i, "amountIn"), 0, maxAmountIn - 1);  // Rounding

--- a/test/unit/SwapExactOut.t.sol
+++ b/test/unit/SwapExactOut.t.sol
@@ -16,7 +16,7 @@ contract PSMSwapExactOutFailureTests is PSMTestBase {
         super.setUp();
 
         // Needed for boundary success conditions
-        usdc.mint(address(psm), 100e6);
+        usdc.mint(pocket, 100e6);
         susds.mint(address(psm), 100e18);
     }
 
@@ -129,7 +129,7 @@ contract PSMSwapExactOutSuccessTestsBase is PSMTestBase {
         // Mint 100x higher than max amount for each token (max conversion rate)
         // Covers both lower and upper bounds of conversion rate (1% to 10,000% are both 100x)
         usds.mint(address(psm),  USDS_TOKEN_MAX  * 100);
-        usdc.mint(address(psm),  USDC_TOKEN_MAX  * 100);
+        usdc.mint(pocket,        USDC_TOKEN_MAX  * 100);
         susds.mint(address(psm), SUSDS_TOKEN_MAX * 100);
     }
 
@@ -145,6 +145,9 @@ contract PSMSwapExactOutSuccessTestsBase is PSMTestBase {
         uint256 psmAssetInBalance  = 100_000_000_000_000 * 10 ** assetIn.decimals();
         uint256 psmAssetOutBalance = 100_000_000_000_000 * 10 ** assetOut.decimals();
 
+        address assetInCustodian  = address(assetIn)  == address(usdc) ? pocket : address(psm);
+        address assetOutCustodian = address(assetOut) == address(usdc) ? pocket : address(psm);
+
         assetIn.mint(swapper_, amountIn);
 
         vm.startPrank(swapper_);
@@ -153,11 +156,11 @@ contract PSMSwapExactOutSuccessTestsBase is PSMTestBase {
 
         assertEq(assetIn.allowance(swapper_, address(psm)), amountIn);
 
-        assertEq(assetIn.balanceOf(swapper_),     amountIn);
-        assertEq(assetIn.balanceOf(address(psm)), psmAssetInBalance);
+        assertEq(assetIn.balanceOf(swapper_),         amountIn);
+        assertEq(assetIn.balanceOf(assetInCustodian), psmAssetInBalance);
 
-        assertEq(assetOut.balanceOf(receiver_),    0);
-        assertEq(assetOut.balanceOf(address(psm)), psmAssetOutBalance);
+        assertEq(assetOut.balanceOf(receiver_),         0);
+        assertEq(assetOut.balanceOf(assetOutCustodian), psmAssetOutBalance);
 
         uint256 returnedAmountIn = psm.swapExactOut(
             address(assetIn),
@@ -172,11 +175,11 @@ contract PSMSwapExactOutSuccessTestsBase is PSMTestBase {
 
         assertEq(assetIn.allowance(swapper_, address(psm)), 0);
 
-        assertEq(assetIn.balanceOf(swapper_),     0);
-        assertEq(assetIn.balanceOf(address(psm)), psmAssetInBalance + amountIn);
+        assertEq(assetIn.balanceOf(swapper_),         0);
+        assertEq(assetIn.balanceOf(assetInCustodian), psmAssetInBalance + amountIn);
 
-        assertEq(assetOut.balanceOf(receiver_),    amountOut);
-        assertEq(assetOut.balanceOf(address(psm)), psmAssetOutBalance - amountOut);
+        assertEq(assetOut.balanceOf(receiver_),         amountOut);
+        assertEq(assetOut.balanceOf(assetOutCustodian), psmAssetOutBalance - amountOut);
     }
 
 }
@@ -205,7 +208,9 @@ contract PSMSwapExactOutUsdsAssetInTests is PSMSwapExactOutSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountOut = _bound(amountOut, 1, USDC_TOKEN_MAX);  // Zero amount reverts
@@ -220,7 +225,9 @@ contract PSMSwapExactOutUsdsAssetInTests is PSMSwapExactOutSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountOut      = _bound(amountOut,      1,       USDS_TOKEN_MAX);
@@ -264,7 +271,9 @@ contract PSMSwapExactOutUsdcAssetInTests is PSMSwapExactOutSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountOut = _bound(amountOut, 1, USDS_TOKEN_MAX);  // Zero amount reverts
@@ -286,7 +295,9 @@ contract PSMSwapExactOutUsdcAssetInTests is PSMSwapExactOutSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountOut      = _bound(amountOut,      1,       SUSDS_TOKEN_MAX);
@@ -332,7 +343,9 @@ contract PSMSwapExactOutSUsdsAssetInTests is PSMSwapExactOutSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountOut      = _bound(amountOut,      1,       USDS_TOKEN_MAX);
@@ -358,7 +371,9 @@ contract PSMSwapExactOutSUsdsAssetInTests is PSMSwapExactOutSuccessTestsBase {
         address fuzzReceiver
     ) public {
         vm.assume(fuzzSwapper  != address(psm));
+        vm.assume(fuzzSwapper  != address(pocket));
         vm.assume(fuzzReceiver != address(psm));
+        vm.assume(fuzzReceiver != address(pocket));
         vm.assume(fuzzReceiver != address(0));
 
         amountOut      = _bound(amountOut,      1,       USDC_TOKEN_MAX);
@@ -435,7 +450,10 @@ contract PSMSwapExactOutFuzzTests is PSMTestBase {
                 assetOut = _getAsset(_hash(i, "assetOut") + 1);
             }
 
-            uint256 amountOut = _bound(_hash(i, "amountOut"), 0, assetOut.balanceOf(address(psm)));
+            address assetOutCustodian = address(assetOut) == address(usdc) ? pocket : address(psm);
+
+            uint256 amountOut
+                = _bound(_hash(i, "amountOut"), 0, assetOut.balanceOf(assetOutCustodian));
 
             uint256 amountIn
                 = psm.previewSwapExactOut(address(assetIn), address(assetOut), amountOut);

--- a/test/unit/Withdraw.t.sol
+++ b/test/unit/Withdraw.t.sol
@@ -58,9 +58,9 @@ contract PSMWithdrawTests is PSMTestBase {
     function test_withdraw_onlyUsdcInPsm() public {
         _deposit(address(usdc), user1, 100e6);
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    0);
-        assertEq(usdc.balanceOf(address(psm)), 100e6);
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), 0);
+        assertEq(usdc.balanceOf(pocket),    100e6);
 
         assertEq(psm.totalShares(), 100e18);
         assertEq(psm.shares(user1), 100e18);
@@ -72,9 +72,9 @@ contract PSMWithdrawTests is PSMTestBase {
 
         assertEq(amount, 100e6);
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    100e6);
-        assertEq(usdc.balanceOf(address(psm)), 0);
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), 100e6);
+        assertEq(usdc.balanceOf(pocket),    0);
 
         assertEq(psm.totalShares(), 0);
         assertEq(psm.shares(user1), 0);
@@ -113,9 +113,9 @@ contract PSMWithdrawTests is PSMTestBase {
         _deposit(address(usdc), user1, 100e6);
         _deposit(address(susds), user1, 100e18);
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    0);
-        assertEq(usdc.balanceOf(address(psm)), 100e6);
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), 0);
+        assertEq(usdc.balanceOf(pocket),    100e6);
 
         assertEq(susds.balanceOf(user1),        0);
         assertEq(susds.balanceOf(receiver1),    0);
@@ -131,9 +131,9 @@ contract PSMWithdrawTests is PSMTestBase {
 
         assertEq(amount, 100e6);
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    100e6);
-        assertEq(usdc.balanceOf(address(psm)), 0);
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), 100e6);
+        assertEq(usdc.balanceOf(pocket),    0);
 
         assertEq(susds.balanceOf(user1),        0);
         assertEq(susds.balanceOf(receiver1),    0);
@@ -149,9 +149,9 @@ contract PSMWithdrawTests is PSMTestBase {
 
         assertEq(amount, 100e18);
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    100e6);
-        assertEq(usdc.balanceOf(address(psm)), 0);
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), 100e6);
+        assertEq(usdc.balanceOf(pocket),    0);
 
         assertEq(susds.balanceOf(user1),        0);
         assertEq(susds.balanceOf(receiver1),    100e18);
@@ -167,9 +167,9 @@ contract PSMWithdrawTests is PSMTestBase {
         _deposit(address(usdc),  user1, 100e6);
         _deposit(address(susds), user1, 100e18);
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    0);
-        assertEq(usdc.balanceOf(address(psm)), 100e6);
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), 0);
+        assertEq(usdc.balanceOf(pocket),    100e6);
 
         assertEq(psm.totalShares(), 225e18);
         assertEq(psm.shares(user1), 225e18);
@@ -181,9 +181,9 @@ contract PSMWithdrawTests is PSMTestBase {
 
         assertEq(amount, 100e6);
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    100e6);
-        assertEq(usdc.balanceOf(address(psm)), 0);
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), 100e6);
+        assertEq(usdc.balanceOf(pocket),    0);
 
         assertEq(psm.totalShares(), 125e18);  // Only burns $100 of shares
         assertEq(psm.shares(user1), 125e18);
@@ -194,9 +194,9 @@ contract PSMWithdrawTests is PSMTestBase {
         _deposit(address(susds), user1, 100e18);
         _deposit(address(usdc),  user2, 200e6);
 
-        assertEq(usdc.balanceOf(user2),        0);
-        assertEq(usdc.balanceOf(receiver2),    0);
-        assertEq(usdc.balanceOf(address(psm)), 300e6);
+        assertEq(usdc.balanceOf(user2),     0);
+        assertEq(usdc.balanceOf(receiver2), 0);
+        assertEq(usdc.balanceOf(pocket),    300e6);
 
         assertEq(psm.totalShares(), 425e18);
         assertEq(psm.shares(user2), 200e18);
@@ -208,9 +208,9 @@ contract PSMWithdrawTests is PSMTestBase {
 
         assertEq(amount, 200e6);
 
-        assertEq(usdc.balanceOf(user2),        0);
-        assertEq(usdc.balanceOf(receiver2),    200e6);  // Gets highest amount possible
-        assertEq(usdc.balanceOf(address(psm)), 100e6);
+        assertEq(usdc.balanceOf(user2),     0);
+        assertEq(usdc.balanceOf(receiver2), 200e6);  // Gets highest amount possible
+        assertEq(usdc.balanceOf(pocket),    100e6);
 
         assertEq(psm.totalShares(), 225e18);
         assertEq(psm.shares(user2), 0);  // Burns the users full amount of shares
@@ -315,9 +315,9 @@ contract PSMWithdrawTests is PSMTestBase {
         vars.totalUsdc  = depositAmount1 + depositAmount2;
         vars.totalValue = vars.totalUsdc * 1e12 + depositAmount3 * 125/100;
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    0);
-        assertEq(usdc.balanceOf(address(psm)), vars.totalUsdc);
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), 0);
+        assertEq(usdc.balanceOf(pocket),    vars.totalUsdc);
 
         assertEq(psm.shares(user1), depositAmount1 * 1e12);
         assertEq(psm.totalShares(), vars.totalValue);
@@ -339,11 +339,11 @@ contract PSMWithdrawTests is PSMTestBase {
         // NOTE: User 1 doesn't need a tolerance because their shares are 1e6 precision because they only
         //       deposited USDC. User 2 has a tolerance because they deposited sUSDS which has 1e18 precision
         //       so there is a chance that the rounding will be off by up to 1e12.
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    vars.expectedWithdrawnAmount1);
-        assertEq(usdc.balanceOf(user2),        0);
-        assertEq(usdc.balanceOf(receiver2),    0);
-        assertEq(usdc.balanceOf(address(psm)), vars.totalUsdc - vars.expectedWithdrawnAmount1);
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), vars.expectedWithdrawnAmount1);
+        assertEq(usdc.balanceOf(user2),     0);
+        assertEq(usdc.balanceOf(receiver2), 0);
+        assertEq(usdc.balanceOf(pocket),    vars.totalUsdc - vars.expectedWithdrawnAmount1);
 
         assertEq(psm.shares(user1), (depositAmount1 - vars.expectedWithdrawnAmount1) * 1e12);
         assertEq(psm.shares(user2), depositAmount2 * 1e12 + depositAmount3 * 125/100);  // Includes sUSDS deposit
@@ -363,11 +363,11 @@ contract PSMWithdrawTests is PSMTestBase {
             vars.totalValue
         );
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    vars.expectedWithdrawnAmount1);
-        assertEq(usdc.balanceOf(user2),        0);
-        assertEq(usdc.balanceOf(receiver2),    vars.expectedWithdrawnAmount2);
-        assertEq(usdc.balanceOf(address(psm)), vars.totalUsdc - (vars.expectedWithdrawnAmount1 + vars.expectedWithdrawnAmount2));
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), vars.expectedWithdrawnAmount1);
+        assertEq(usdc.balanceOf(user2),     0);
+        assertEq(usdc.balanceOf(receiver2), vars.expectedWithdrawnAmount2);
+        assertEq(usdc.balanceOf(pocket),    vars.totalUsdc - (vars.expectedWithdrawnAmount1 + vars.expectedWithdrawnAmount2));
 
         assertEq(susds.balanceOf(user2),        0);
         assertEq(susds.balanceOf(receiver2),    0);
@@ -404,11 +404,11 @@ contract PSMWithdrawTests is PSMTestBase {
             1
         );
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(receiver1),    vars.expectedWithdrawnAmount1);
-        assertEq(usdc.balanceOf(user2),        0);
-        assertEq(usdc.balanceOf(receiver2),    vars.expectedWithdrawnAmount2);
-        assertEq(usdc.balanceOf(address(psm)), vars.totalUsdc - (vars.expectedWithdrawnAmount1 + vars.expectedWithdrawnAmount2));
+        assertEq(usdc.balanceOf(user1),     0);
+        assertEq(usdc.balanceOf(receiver1), vars.expectedWithdrawnAmount1);
+        assertEq(usdc.balanceOf(user2),     0);
+        assertEq(usdc.balanceOf(receiver2), vars.expectedWithdrawnAmount2);
+        assertEq(usdc.balanceOf(pocket),    vars.totalUsdc - (vars.expectedWithdrawnAmount1 + vars.expectedWithdrawnAmount2));
 
         assertApproxEqAbs(susds.balanceOf(user2),        0,                                              0);
         assertApproxEqAbs(susds.balanceOf(receiver2),    vars.expectedWithdrawnAmount3,                  1);
@@ -430,7 +430,7 @@ contract PSMWithdrawTests is PSMTestBase {
     }
 
     function test_withdraw_changeConversionRate() public {
-        _deposit(address(usdc), user1, 100e6);
+        _deposit(address(usdc),  user1, 100e6);
         _deposit(address(susds), user2, 100e18);
 
         assertEq(psm.convertToShares(1e18), 1e18);
@@ -444,8 +444,8 @@ contract PSMWithdrawTests is PSMTestBase {
 
         assertEq(psm.convertToShares(1e18), 0.9e18);
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(address(psm)), 100e6);
+        assertEq(usdc.balanceOf(user1),  0);
+        assertEq(usdc.balanceOf(pocket), 100e6);
 
         assertEq(psm.totalShares(), 225e18);
         assertEq(psm.shares(user1), 100e18);
@@ -457,8 +457,8 @@ contract PSMWithdrawTests is PSMTestBase {
 
         assertEq(amount, 100e6);
 
-        assertEq(usdc.balanceOf(user1),        100e6);
-        assertEq(usdc.balanceOf(address(psm)), 0);
+        assertEq(usdc.balanceOf(user1),  100e6);
+        assertEq(usdc.balanceOf(pocket), 0);
 
         assertEq(susds.balanceOf(user1),        0);
         assertEq(susds.balanceOf(user2),        0);
@@ -541,8 +541,8 @@ contract PSMWithdrawTests is PSMTestBase {
         assertEq(psm.shares(user1), user1Shares);
         assertEq(psm.shares(user2), user2Shares);
 
-        assertEq(usdc.balanceOf(user1),        0);
-        assertEq(usdc.balanceOf(address(psm)), usdcAmount);
+        assertEq(usdc.balanceOf(user1),  0);
+        assertEq(usdc.balanceOf(pocket), usdcAmount);
 
         // NOTE: Users shares have more value than the balance of USDC now
         vm.prank(user1);
@@ -550,8 +550,8 @@ contract PSMWithdrawTests is PSMTestBase {
 
         assertEq(amount, usdcAmount);  // Withdraws all USDC since shares are worth more
 
-        assertEq(usdc.balanceOf(user1),        usdcAmount);
-        assertEq(usdc.balanceOf(address(psm)), 0);
+        assertEq(usdc.balanceOf(user1),  usdcAmount);
+        assertEq(usdc.balanceOf(pocket), 0);
 
         assertEq(susds.balanceOf(user1),        0);
         assertEq(susds.balanceOf(user2),        0);
@@ -618,7 +618,7 @@ contract PSMWithdrawTests is PSMTestBase {
         uint256 totalSharesValue = psm.convertToAssetValue(psm.totalShares());
         uint256 totalAssetsValue =
             susds.balanceOf(address(psm)) * rateProvider.getConversionRate() / 1e27
-            + usdc.balanceOf(address(psm)) * 1e12;
+            + usdc.balanceOf(pocket) * 1e12;
 
         assertApproxEqAbs(totalSharesValue, totalAssetsValue, 1);
     }
@@ -626,7 +626,9 @@ contract PSMWithdrawTests is PSMTestBase {
     function _getExpectedWithdrawnAmount(MockERC20 asset, address user, uint256 amount)
         internal view returns (uint256 withdrawAmount)
     {
-        uint256 balance    = asset.balanceOf(address(psm));
+        address custodian = address(asset) == address(usdc) ? pocket : address(psm);
+
+        uint256 balance    = asset.balanceOf(custodian);
         uint256 userAssets = psm.convertToAssets(address(asset), psm.shares(user));
 
         // Return the min of assets, balance, and amount

--- a/test/unit/harnesses/PSM3Harness.sol
+++ b/test/unit/harnesses/PSM3Harness.sol
@@ -32,4 +32,8 @@ contract PSM3Harness is PSM3 {
         return _getSUsdsValue(amount, roundUp);
     }
 
+    function getAssetCustodian(address asset) external view returns (address) {
+        return _getAssetCustodian(asset);
+    }
+
 }


### PR DESCRIPTION
Updates to:
- Account for balance of USDC in pocket for totalAssets() accounting
- Transfer assets in and out of the pocket for deposit/withdraw/swaps
- Add an invariant test suite to set the pocket and maintain accounting
- Add additional test coverage for different pocket scenarios
- Add coverage to demonstrate breaking accounting (Start with PSM as default, get deposits, transfer pocket to another address, check totalAssets - this saw a drop in totalAssets before fix)
- Update testing to use a non-psm pocket by default